### PR TITLE
feat(P4-PR3): implement GET /v1/audit/requests/:request_id endpoint

### DIFF
--- a/src/gateway/routes.ts
+++ b/src/gateway/routes.ts
@@ -117,12 +117,25 @@ export function registerRoutes(
     return reply.send({ data: services.providerRegistry.listModels() });
   });
 
-  app.get("/v1/audit/requests/:request_id", async (_request, reply) => {
-    return reply.status(501).send({
-      error: {
-        code: "internal_error",
-        message: "Audit query not yet implemented",
-      },
+  app.get("/v1/audit/requests/:request_id", async (request, reply) => {
+    const { request_id } = request.params as { request_id: string };
+
+
+    const auditRecord = await services.receiptService.getByRequestId(
+      request_id as import("../types.js").RequestId,
+    );
+
+    if (!auditRecord) {
+      return reply.status(404).send({
+        error: {
+          code: "not_found",
+          message: `Request ${request_id} not found or incomplete`,
+        },
+      });
+    }
+
+    return reply.send({
+      data: auditRecord,
     });
   });
 }

--- a/test/integration/flow.test.ts
+++ b/test/integration/flow.test.ts
@@ -1,50 +1,52 @@
-import { describe, it, expect } from 'vitest';
-import { buildTestApp } from '../helpers.js';
+import { describe, it, expect } from "vitest";
+import { buildTestApp } from "../helpers.js";
 
-describe('API Integration', () => {
-  describe('GET /v1/models', () => {
-    it('should return empty model catalog', async () => {
+describe("API Integration", () => {
+  describe("GET /v1/models", () => {
+    it("should return empty model catalog", async () => {
       const app = buildTestApp();
       const response = await app.inject({
-        method: 'GET',
-        url: '/v1/models',
+        method: "GET",
+        url: "/v1/models",
       });
 
       expect(response.statusCode).toBe(200);
       const body = response.json();
-      expect(body).toHaveProperty('data');
+      expect(body).toHaveProperty("data");
       expect(body.data).toEqual([]);
     });
   });
 
-  describe('POST /v1/chat/completions', () => {
-    it('should return 402 without payment headers', async () => {
+  describe("POST /v1/chat/completions", () => {
+    it("should return 402 without payment headers", async () => {
       const app = buildTestApp();
       const response = await app.inject({
-        method: 'POST',
-        url: '/v1/chat/completions',
+        method: "POST",
+        url: "/v1/chat/completions",
         payload: {
-          model: 'gpt-4',
-          messages: [{ role: 'user', content: 'hello' }],
+          model: "gpt-4",
+          messages: [{ role: "user", content: "hello" }],
         },
       });
 
       expect(response.statusCode).toBe(402);
       const body = response.json();
-      expect(body.error.code).toBe('payment_required');
-      expect(body).toHaveProperty('payment_requirements');
+      expect(body.error.code).toBe("payment_required");
+      expect(body).toHaveProperty("payment_requirements");
     });
   });
 
-  describe('GET /v1/audit/requests/:request_id', () => {
-    it('should return 501 (not yet implemented)', async () => {
+  describe("GET /v1/audit/requests/:request_id", () => {
+    it("should return 404 for non-existent request", async () => {
       const app = buildTestApp();
       const response = await app.inject({
-        method: 'GET',
-        url: '/v1/audit/requests/req_test123',
+        method: "GET",
+        url: "/v1/audit/requests/req_test123",
       });
 
-      expect(response.statusCode).toBe(501);
+      expect(response.statusCode).toBe(404);
+      const body = response.json();
+      expect(body.error.code).toBe("not_found");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Implement GET /v1/audit/requests/:request_id endpoint
- Replace placeholder 501 response with actual audit query using receiptService
- Return 404 for non-existent requests with 'not_found' error code
- Return audit data wrapped in { data: ... } format
- Update integration test to verify 404 behavior

## Changes
- src/gateway/routes.ts: Audit endpoint implementation
- test/integration/flow.test.ts: Update test expectations

## Test Results
✅ All 123 tests passed
✅ TypeScript compilation passed
✅ ESLint passed

## PR Size
- Files: 2 (≤4) ✅
- Lines: 42 insertions, 28 deletions ✅

## Verification Checklist
- [x] PR size ≤4 files, ≤200 lines (excluding tests)
- [x] Module boundaries respected (gateway module only)
- [x] Handler remains thin (delegates to receiptService)
- [x] Error codes properly defined
- [x] MVP scope respected
- [x] All tests passing

Part of P4: Audit Interface phase (21/25 PRs - 84%)