### PR TITLE
feat(P5-PR4): add simulation testing environment

### DIFF
--- a/test/simulation/environment.ts
+++ b/test/simulation/environment.ts
@@ -1,0 +1,361 @@
+/**
+ * Simulation Environment - Full-stack simulation for load testing
+ *
+ * This module provides a complete simulation environment for testing
+ * the x402 gateway under realistic load conditions.
+ */
+
+import Fastify from "fastify";
+import { registerRoutes } from "../../src/gateway/routes.js";
+import { createProviderRegistry } from "../../src/provider/registry.js";
+import { createChallengeService } from "../../src/x402/challenge.service.js";
+import { createMeterService } from "../../src/billing/meter.service.js";
+import { createCostService } from "../../src/billing/cost.service.js";
+import { createLedgerService } from "../../src/billing/ledger.service.js";
+import { createTraceService } from "../../src/audit/trace.service.js";
+import { createReceiptService } from "../../src/audit/receipt.service.js";
+import type { ServiceContainer } from "../../src/app.js";
+import type { ChatCompletionRequest, RoutingMode } from "../../src/types.js";
+import type { PaymentProof, VerificationResult } from "../../src/x402/types.js";
+import type {
+  UpstreamResponse,
+  ProviderAdapter,
+} from "../../src/provider/types.js";
+import type { RouteDecision } from "../../src/router/types.js";
+import {
+  PaymentReplayedError,
+  InsufficientPaymentError,
+  PaymentVerificationFailedError,
+} from "../../src/errors.js";
+
+/**
+ * Simulated LLM provider that mimics real API behavior with configurable latency
+ */
+export interface SimulatedProvider {
+  name: string;
+  models: string[];
+  latencyMs: { min: number; max: number };
+  failureRate: number; // 0-1 probability of failure
+  rateLimitRPS: number;
+}
+
+/**
+ * Default simulation configuration
+ */
+export const DEFAULT_SIMULATION_CONFIG = {
+  providers: [
+    {
+      name: "openai",
+      models: ["gpt-4o", "gpt-4o-mini"],
+      latencyMs: { min: 100, max: 500 },
+      failureRate: 0.01,
+      rateLimitRPS: 100,
+    },
+    {
+      name: "anthropic",
+      models: ["claude-3-opus", "claude-3-sonnet"],
+      latencyMs: { min: 150, max: 600 },
+      failureRate: 0.02,
+      rateLimitRPS: 80,
+    },
+  ] as SimulatedProvider[],
+  verificationLatencyMs: { min: 50, max: 150 },
+  blockchainConfirmations: 6,
+  replayProtectionEnabled: true,
+};
+
+/**
+ * Create a simulated model adapter with realistic behavior
+ */
+export function createSimulatedAdapter(
+  provider: SimulatedProvider,
+  options?: { currentRPS?: number },
+): ProviderAdapter {
+  return {
+    providerId: provider.name,
+
+    execute: async (
+      request: ChatCompletionRequest,
+      modelId: string,
+    ): Promise<UpstreamResponse> => {
+      // Check rate limit
+      if (options?.currentRPS && options.currentRPS > provider.rateLimitRPS) {
+        throw new Error(`Rate limit exceeded for ${provider.name}`);
+      }
+
+      // Simulate random failures
+      if (Math.random() < provider.failureRate) {
+        throw new Error(`Simulated ${provider.name} API failure`);
+      }
+
+      // Simulate latency
+      const latencyMs =
+        Math.floor(
+          Math.random() * (provider.latencyMs.max - provider.latencyMs.min + 1),
+        ) + provider.latencyMs.min;
+      await new Promise((resolve) => setTimeout(resolve, latencyMs));
+
+      // Generate realistic token counts based on request
+      const promptTokens = Math.floor(
+        request.messages.reduce((acc, m) => acc + m.content.length / 4, 0),
+      );
+      const completionTokens = Math.floor(Math.random() * 200) + 50;
+
+      return {
+        model_used: `${provider.name}/${modelId || provider.models[0]}`,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: `[Simulated ${provider.name} response]`,
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: {
+          prompt_tokens: promptTokens,
+          completion_tokens: completionTokens,
+          total_tokens: promptTokens + completionTokens,
+        },
+        latency_ms: latencyMs,
+      };
+    },
+
+    healthCheck: async (): Promise<boolean> => {
+      return Math.random() > provider.failureRate;
+    },
+  };
+}
+
+/**
+ * Create simulated payment verification service
+ */
+export function createSimulatedVerifyService(options?: {
+  latencyMs?: { min: number; max: number };
+  failureRate?: number;
+}) {
+  const latencyMs = options?.latencyMs ?? { min: 50, max: 150 };
+  const failureRate = options?.failureRate ?? 0.01;
+
+  return {
+    verifyPayment: async (
+      proof: PaymentProof,
+      challenge: { amount: string },
+    ): Promise<VerificationResult> => {
+      // Simulate verification latency
+      const delay =
+        Math.floor(Math.random() * (latencyMs.max - latencyMs.min + 1)) +
+        latencyMs.min;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+
+      // Simulate random verification failures
+      if (Math.random() < failureRate) {
+        throw new PaymentVerificationFailedError(
+          "Simulated verification failure",
+        );
+      }
+
+      // Simulate insufficient payment (1% chance)
+      if (Math.random() < 0.01) {
+        throw new InsufficientPaymentError(challenge.amount, "0.0001");
+      }
+
+      return {
+        verified: true,
+        payer_address: proof.payer_address,
+        amount: challenge.amount,
+      };
+    },
+  };
+}
+
+/**
+ * Create simulated replay protection with realistic storage behavior
+ */
+export function createSimulatedReplayService() {
+  const seenHashes = new Set<string>();
+  const idempotencyStore = new Map<string, unknown>();
+
+  return {
+    checkAndMark: async (
+      hash: string,
+      ttlSeconds: number,
+    ): Promise<boolean> => {
+      // Simulate storage latency
+      await new Promise((resolve) => setTimeout(resolve, Math.random() * 10));
+
+      if (seenHashes.has(hash)) {
+        throw new PaymentReplayedError();
+      }
+      seenHashes.add(hash);
+
+      // Simulate TTL cleanup (simplified)
+      setTimeout(() => {
+        seenHashes.delete(hash);
+      }, ttlSeconds * 1000);
+
+      return true;
+    },
+
+    checkIdempotency: async (key: string) => {
+      await new Promise((resolve) => setTimeout(resolve, Math.random() * 5));
+      return idempotencyStore.get(key) || null;
+    },
+
+    saveIdempotency: async (
+      key: string,
+      response: unknown,
+      ttlSeconds: number,
+    ) => {
+      await new Promise((resolve) => setTimeout(resolve, Math.random() * 10));
+      idempotencyStore.set(key, response);
+
+      setTimeout(() => {
+        idempotencyStore.delete(key);
+      }, ttlSeconds * 1000);
+    },
+  };
+}
+
+/**
+ * Create simulated router with realistic routing behavior
+ */
+export function createSimulatedRouterService(
+  providers: SimulatedProvider[],
+  options?: { mode: RoutingMode },
+) {
+  const adapters = new Map(
+    providers.map((p) => [p.name, createSimulatedAdapter(p)]),
+  );
+
+  return {
+    route: async (
+      request: ChatCompletionRequest,
+      mode: RoutingMode,
+    ): Promise<{ decision: RouteDecision; response: UpstreamResponse }> => {
+      const effectiveMode = options?.mode ?? mode;
+
+      if (effectiveMode === "manual") {
+        const [providerName, modelName] = request.model.split("/");
+        const adapter = adapters.get(providerName);
+
+        if (!adapter) {
+          throw new Error(`Provider ${providerName} not found`);
+        }
+
+        const response = await adapter.execute(
+          request,
+          modelName || request.model,
+        );
+
+        const decision: RouteDecision = {
+          selected_model: request.model,
+          fallback_chain: [],
+          score_summary: "manual selection",
+          route_proof_hash: `rph_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+        };
+
+        return { decision, response };
+      }
+
+      // Auto mode - simple round-robin for simulation
+      const providerList = Array.from(adapters.values());
+      const selectedAdapter =
+        providerList[Math.floor(Math.random() * providerList.length)];
+
+      const response = await selectedAdapter.execute(request, request.model);
+
+      const decision: RouteDecision = {
+        selected_model: response.model_used,
+        fallback_chain: [],
+        score_summary: "auto selection (simulated)",
+        route_proof_hash: `rph_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+      };
+
+      return { decision, response };
+    },
+  };
+}
+
+/**
+ * Build a fully simulated test environment for load testing
+ */
+export function buildSimulationEnvironment(
+  config = DEFAULT_SIMULATION_CONFIG,
+): {
+  app: ReturnType<typeof Fastify>;
+  services: ServiceContainer;
+  metrics: {
+    getRequestCount: () => number;
+    getErrorCount: () => number;
+    getAverageLatency: () => number;
+    reset: () => void;
+  };
+} {
+  const providerRegistry = createProviderRegistry();
+  const ledgerService = createLedgerService();
+  const traceService = createTraceService();
+
+  // Track metrics
+  let requestCount = 0;
+  let errorCount = 0;
+  let totalLatency = 0;
+
+  const services: ServiceContainer = {
+    providerRegistry,
+    challengeService: createChallengeService({
+      challengeSecret: "sim-secret-at-least-32-chars-long-for-simulations",
+      challengeTtlSeconds: 300,
+      merchantAddress: "0x0000000000000000000000000000000000000001",
+      paymentChain: "base",
+      paymentAsset: "USDC",
+    }),
+    verifyService: createSimulatedVerifyService({
+      latencyMs: config.verificationLatencyMs,
+    }),
+    replayService: createSimulatedReplayService(),
+    routerService: createSimulatedRouterService(config.providers),
+    meterService: createMeterService({ recordUsage: async () => {} }),
+    costService: createCostService(),
+    ledgerService,
+    traceService,
+    receiptService: createReceiptService({ traceService, ledgerService }),
+  };
+
+  // Wrap router to track metrics
+  const originalRoute = services.routerService.route.bind(
+    services.routerService,
+  );
+  services.routerService.route = async (request, mode) => {
+    const startTime = Date.now();
+    requestCount++;
+    try {
+      const result = await originalRoute(request, mode);
+      totalLatency += Date.now() - startTime;
+      return result;
+    } catch (error) {
+      errorCount++;
+      throw error;
+    }
+  };
+
+  const app = Fastify({ logger: false });
+  registerRoutes(app, services);
+
+  return {
+    app,
+    services,
+    metrics: {
+      getRequestCount: () => requestCount,
+      getErrorCount: () => errorCount,
+      getAverageLatency: () =>
+        requestCount > 0 ? totalLatency / requestCount : 0,
+      reset: () => {
+        requestCount = 0;
+        errorCount = 0;
+        totalLatency = 0;
+      },
+    },
+  };
+}

--- a/test/simulation/simulation.test.ts
+++ b/test/simulation/simulation.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Simulation Tests - Full-stack simulation testing
+ *
+ * Tests the x402 gateway under simulated production conditions
+ * using realistic provider behavior and network conditions.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  buildSimulationEnvironment,
+  createSimulatedAdapter,
+  createSimulatedVerifyService,
+  createSimulatedReplayService,
+  createSimulatedRouterService,
+  DEFAULT_SIMULATION_CONFIG,
+  type SimulatedProvider,
+} from "./environment.js";
+import type { PaymentProof } from "../../src/x402/types.js";
+
+describe("Simulation Environment", () => {
+  describe("Simulated Adapter", () => {
+    it("should simulate provider latency", async () => {
+      const provider: SimulatedProvider = {
+        name: "test-provider",
+        models: ["test-model"],
+        latencyMs: { min: 50, max: 100 },
+        failureRate: 0,
+        rateLimitRPS: 1000,
+      };
+
+      const adapter = createSimulatedAdapter(provider);
+      const startTime = Date.now();
+
+      const response = await adapter.execute(
+        {
+          model: "test-model",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+        "test-model",
+      );
+
+      const elapsed = Date.now() - startTime;
+
+      expect(response).toBeDefined();
+      expect(response.model_used).toContain("test-provider");
+      expect(elapsed).toBeGreaterThanOrEqual(45); // Allow small variance
+      expect(response.usage.prompt_tokens).toBeGreaterThan(0);
+      expect(response.usage.completion_tokens).toBeGreaterThan(0);
+    });
+
+    it("should simulate provider failures based on failure rate", async () => {
+      const provider: SimulatedProvider = {
+        name: "unstable-provider",
+        models: ["test-model"],
+        latencyMs: { min: 10, max: 20 },
+        failureRate: 1.0, // Always fail
+        rateLimitRPS: 1000,
+      };
+
+      const adapter = createSimulatedAdapter(provider);
+
+      await expect(
+        adapter.execute(
+          {
+            model: "test-model",
+            messages: [{ role: "user", content: "Hello" }],
+          },
+          "test-model",
+        ),
+      ).rejects.toThrow("Simulated unstable-provider API failure");
+    });
+
+    it("should calculate prompt tokens based on message length", async () => {
+      const provider: SimulatedProvider = {
+        name: "test-provider",
+        models: ["test-model"],
+        latencyMs: { min: 1, max: 5 },
+        failureRate: 0,
+        rateLimitRPS: 1000,
+      };
+
+      const adapter = createSimulatedAdapter(provider);
+
+      const response = await adapter.execute(
+        {
+          model: "test-model",
+          messages: [
+            { role: "user", content: "a".repeat(100) }, // 100 chars
+          ],
+        },
+        "test-model",
+      );
+
+      // Token count should be roughly content.length / 4
+      expect(response.usage.prompt_tokens).toBeGreaterThan(20);
+      expect(response.usage.prompt_tokens).toBeLessThan(30);
+    });
+  });
+
+  describe("Simulated Verification Service", () => {
+    it("should verify payment with realistic latency", async () => {
+      const service = createSimulatedVerifyService({
+        latencyMs: { min: 50, max: 100 },
+        failureRate: 0,
+      });
+
+      const proof: PaymentProof = {
+        tx_hash: "0x" + "a".repeat(64),
+        chain: "base",
+        payer_address: "0x1234567890123456789012345678901234567890",
+      };
+
+      const startTime = Date.now();
+      const result = await service.verifyPayment(proof, { amount: "0.001" });
+      const elapsed = Date.now() - startTime;
+
+      expect(result.verified).toBe(true);
+      expect(result.payer_address).toBe(proof.payer_address);
+      expect(elapsed).toBeGreaterThanOrEqual(45);
+    });
+
+    it("should fail verification based on failure rate", async () => {
+      const service = createSimulatedVerifyService({
+        latencyMs: { min: 10, max: 20 },
+        failureRate: 1.0, // Always fail
+      });
+
+      const proof: PaymentProof = {
+        tx_hash: "0x" + "a".repeat(64),
+        chain: "base",
+        payer_address: "0x1234567890123456789012345678901234567890",
+      };
+
+      await expect(
+        service.verifyPayment(proof, { amount: "0.001" }),
+      ).rejects.toThrow("Simulated verification failure");
+    });
+  });
+
+  describe("Simulated Replay Service", () => {
+    it("should prevent replay attacks", async () => {
+      const service = createSimulatedReplayService();
+      const hash = "test-hash-123";
+
+      // First check should pass
+      await expect(service.checkAndMark(hash, 60)).resolves.toBe(true);
+
+      // Second check should fail with replay error
+      await expect(service.checkAndMark(hash, 60)).rejects.toThrow();
+    });
+
+    it("should support idempotency", async () => {
+      const service = createSimulatedReplayService();
+      const key = "idem-key-123";
+      const response = { id: "test-123", status: "success" };
+
+      // Check should return null initially
+      expect(await service.checkIdempotency(key)).toBeNull();
+
+      // Save idempotency
+      await service.saveIdempotency(key, response, 60);
+
+      // Check should return saved response
+      expect(await service.checkIdempotency(key)).toEqual(response);
+    });
+  });
+
+  describe("Simulated Router", () => {
+    it("should route to provider in manual mode", async () => {
+      const providers: SimulatedProvider[] = [
+        {
+          name: "openai",
+          models: ["gpt-4o"],
+          latencyMs: { min: 10, max: 20 },
+          failureRate: 0,
+          rateLimitRPS: 1000,
+        },
+      ];
+
+      const router = createSimulatedRouterService(providers, {
+        mode: "manual",
+      });
+
+      const result = await router.route(
+        {
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+        "manual",
+      );
+
+      expect(result.decision.selected_model).toBe("openai/gpt-4o");
+      expect(result.response.model_used).toContain("openai");
+    });
+
+    it("should throw error for unknown provider", async () => {
+      const providers: SimulatedProvider[] = [
+        {
+          name: "openai",
+          models: ["gpt-4o"],
+          latencyMs: { min: 10, max: 20 },
+          failureRate: 0,
+          rateLimitRPS: 1000,
+        },
+      ];
+
+      const router = createSimulatedRouterService(providers, {
+        mode: "manual",
+      });
+
+      await expect(
+        router.route(
+          {
+            model: "unknown/model",
+            messages: [{ role: "user", content: "Hello" }],
+          },
+          "manual",
+        ),
+      ).rejects.toThrow("Provider unknown not found");
+    });
+  });
+
+  describe("Full Simulation Environment", () => {
+    let env: ReturnType<typeof buildSimulationEnvironment>;
+
+    beforeEach(() => {
+      env = buildSimulationEnvironment();
+      env.metrics.reset();
+    });
+
+    it("should complete full 402 flow in simulation", async () => {
+      // Step 1: Get challenge
+      const challengeResponse = await env.app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        payload: {
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+      });
+
+      expect(challengeResponse.statusCode).toBe(402);
+      const challengeBody = challengeResponse.json();
+      const challengeToken = challengeBody.payment_requirements.challenge_token;
+
+      // Step 2: Submit payment
+      const paymentProof: PaymentProof = {
+        tx_hash: "0x" + "a".repeat(64),
+        chain: "base",
+        payer_address: "0x1234567890123456789012345678901234567890",
+      };
+      const paymentHeader = Buffer.from(JSON.stringify(paymentProof)).toString(
+        "base64url",
+      );
+
+      const successResponse = await env.app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        payload: {
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+        headers: {
+          "x-402-challenge": challengeToken,
+          "x-402-payment": paymentHeader,
+        },
+      });
+
+      expect(successResponse.statusCode).toBe(200);
+      const body = successResponse.json();
+      expect(body.usage_receipt).toBeDefined();
+      expect(body.usage_receipt.model_used).toContain("openai");
+    });
+
+    it("should track metrics correctly", async () => {
+      const paymentProof: PaymentProof = {
+        tx_hash: "0x" + "b".repeat(64),
+        chain: "base",
+        payer_address: "0x1234567890123456789012345678901234567890",
+      };
+
+      // Get challenge
+      const challengeResponse = await env.app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        payload: {
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "Test" }],
+        },
+      });
+
+      const challengeToken =
+        challengeResponse.json().payment_requirements.challenge_token;
+      const paymentHeader = Buffer.from(JSON.stringify(paymentProof)).toString(
+        "base64url",
+      );
+
+      // Submit request
+      await env.app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        payload: {
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "Test" }],
+        },
+        headers: {
+          "x-402-challenge": challengeToken,
+          "x-402-payment": paymentHeader,
+        },
+      });
+
+      // Verify metrics were tracked
+      expect(env.metrics.getRequestCount()).toBeGreaterThan(0);
+      expect(env.metrics.getAverageLatency()).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Simulation with Custom Config", () => {
+    it("should use custom provider configuration", async () => {
+      const customConfig = {
+        ...DEFAULT_SIMULATION_CONFIG,
+        providers: [
+          {
+            name: "custom-provider",
+            models: ["custom-model"],
+            latencyMs: { min: 5, max: 10 },
+            failureRate: 0,
+            rateLimitRPS: 10000,
+          },
+        ],
+      };
+
+      const env = buildSimulationEnvironment(customConfig);
+
+      const challengeResponse = await env.app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        payload: {
+          model: "custom-provider/custom-model",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+      });
+
+      expect(challengeResponse.statusCode).toBe(402);
+
+      const paymentProof: PaymentProof = {
+        tx_hash: "0x" + "c".repeat(64),
+        chain: "base",
+        payer_address: "0x1234567890123456789012345678901234567890",
+      };
+
+      const successResponse = await env.app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        payload: {
+          model: "custom-provider/custom-model",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+        headers: {
+          "x-402-challenge":
+            challengeResponse.json().payment_requirements.challenge_token,
+          "x-402-payment": Buffer.from(JSON.stringify(paymentProof)).toString(
+            "base64url",
+          ),
+        },
+      });
+
+      expect(successResponse.statusCode).toBe(200);
+      expect(successResponse.json().model).toContain("custom-provider");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **P5-PR4**: Add simulation testing environment for load testing
- **Files**: 2 new files (test/simulation/environment.ts, test/simulation/simulation.test.ts)
- **Tests**: 12/12 passed

## Changes

### test/simulation/environment.ts (361 lines)
- `SimulatedProvider` interface for configuring LLM provider behavior
- `createSimulatedAdapter()` - Realistic LLM API simulation with latency/failure
- `createSimulatedVerifyService()` - Payment verification simulation
- `createSimulatedReplayService()` - Replay protection simulation
- `createSimulatedRouterService()` - Router simulation
- `buildSimulationEnvironment()` - Full simulation environment builder
- `DEFAULT_SIMULATION_CONFIG` - Default OpenAI + Anthropic config

### test/simulation/simulation.test.ts (372 lines)
- 12 test cases covering adapter, verification, replay, router, and full flow
- All tests passing ✅

## Verification

- [x] TypeScript compiles
- [x] ESLint passes (32 warnings are pre-existing console statements)
- [x] All simulation tests pass (12/12)
- [x] No production code changes

## Notes

This completes P5 (Integration Testing + Simulation Environment):
- P5-PR1: End-to-end integration tests ✅
- P5-PR2: Blockchain mock ✅
- P5-PR3: Performance test script ✅
- P5-PR4: Simulation testing environment ✅