### PR TITLE
fix(P6-PR2): Audit response format + Model registration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -47,6 +47,7 @@ import { registerRoutes } from "./gateway/routes.js";
 import {
   createProviderRegistry,
   type IProviderRegistry,
+  OpenAIAdapter,
 } from "./provider/index.js";
 import {
   createChallengeService,
@@ -131,6 +132,25 @@ export async function buildApp(config: Config) {
   });
 
   const providerRegistry = createProviderRegistry();
+
+  // Register default models for testing/development
+  providerRegistry.register("openai/gpt-4o", new OpenAIAdapter("test-key"), {
+    input_usd_per_token: "0.00001",
+    output_usd_per_token: "0.00003",
+    effective_at: new Date().toISOString(),
+  });
+
+  // Register cheaper model for auto routing tests
+  providerRegistry.register(
+    "openai/gpt-3.5-turbo",
+    new OpenAIAdapter("test-key"),
+    {
+      input_usd_per_token: "0.000005",
+      output_usd_per_token: "0.000015",
+      effective_at: new Date().toISOString(),
+    },
+  );
+
   const ledgerService = createLedgerService();
   const traceService = createTraceService();
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -134,16 +134,21 @@ export async function buildApp(config: Config) {
   const providerRegistry = createProviderRegistry();
 
   // Register default models for testing/development
-  providerRegistry.register("openai/gpt-4o", new OpenAIAdapter("test-key"), {
-    input_usd_per_token: "0.00001",
-    output_usd_per_token: "0.00003",
-    effective_at: new Date().toISOString(),
-  });
+  // Use config.openaiApiKey if provided, fallback to test-key for dev
+  providerRegistry.register(
+    "openai/gpt-4o",
+    new OpenAIAdapter(config.openaiApiKey || "test-key"),
+    {
+      input_usd_per_token: "0.00001",
+      output_usd_per_token: "0.00003",
+      effective_at: new Date().toISOString(),
+    },
+  );
 
   // Register cheaper model for auto routing tests
   providerRegistry.register(
     "openai/gpt-3.5-turbo",
-    new OpenAIAdapter("test-key"),
+    new OpenAIAdapter(config.openaiApiKey || "test-key"),
     {
       input_usd_per_token: "0.000005",
       output_usd_per_token: "0.000015",

--- a/src/gateway/routes.ts
+++ b/src/gateway/routes.ts
@@ -229,8 +229,6 @@ export function registerRoutes(
       });
     }
 
-    return reply.send({
-      data: auditRecord,
-    });
+    return reply.send(auditRecord);
   });
 }

--- a/test/integration/flow.test.ts
+++ b/test/integration/flow.test.ts
@@ -514,11 +514,7 @@ describe("End-to-End Integration Flow", () => {
       });
 
       expect(auditResponse.statusCode).toBe(200);
-      const auditBody = auditResponse.json();
-      expect(auditBody.data).toBeDefined();
-
-      // Verify audit record structure
-      const auditRecord = auditBody.data;
+      const auditRecord = auditResponse.json();
       expect(auditRecord.request_id).toBe(requestId);
       expect(auditRecord.request_hash).toBeDefined();
       expect(auditRecord.routing_mode).toBe("manual");


### PR DESCRIPTION
## Summary

Fixes 2 issues from code audit (Issue #37):

### Issues Fixed

| Issue | Priority | Description | Status |
|-------|----------|-------------|--------|
| SI-002 | 🔴 P0 | Audit endpoint response format now matches API spec | ✅ Fixed |
| SI-004 | 🟡 P1 | Register default models on startup | ✅ Fixed |

### Changes

**1. src/gateway/routes.ts**
- Remove `{ data: ... }` wrapper from audit endpoint response
- Now returns `auditRecord` directly per API spec Section 5

**2. src/app.ts**
- Import `OpenAIAdapter` from provider module
- Register `openai/gpt-4o` with pricing ($0.01/$0.03 per 1K tokens)
- Register `openai/gpt-3.5-turbo` with pricing ($0.005/$0.015 per 1K tokens)
- GET `/v1/models` now returns non-empty model catalog

**3. test/integration/flow.test.ts**
- Update audit endpoint test to match new response format
- Remove `auditBody.data` expectation, use `auditRecord` directly

### Testing

```bash
$ pnpm typecheck
✅ PASS - No TypeScript errors

$ pnpm lint  
✅ PASS - 32 warnings (pre-existing in load.test.ts)

$ pnpm test test/integration/flow.test.ts
✅ PASS - 15/15 tests

$ pnpm test test/audit/receipt.test.ts
✅ PASS - 29/29 tests

$ pnpm test test/billing/ test/x402/ test/router/router.test.ts
✅ PASS - 92/92 tests
```

### Verification

- Audit endpoint now returns unwrapped audit record
- Model catalog endpoint returns 2 registered models
- All existing tests continue to pass

### PR Size

| Metric | Value | Constraint | Status |
|--------|-------|------------|--------|
| Files changed | 2 src + 1 test | ≤3 src files | ✅ |
| Lines changed | +22/-8 | ≤200 | ✅ |

---

**Next**: After merge, proceed to P6-PR3 (Hardcoded pricing fix)