### PR TITLE
fix(P6-PR3): Remove hardcoded pricing, use provider registry

### DIFF
--- a/src/gateway/routes.ts
+++ b/src/gateway/routes.ts
@@ -108,12 +108,10 @@ export function registerRoutes(
           response,
         );
 
-        // Get pricing and calculate cost
-        const pricing = {
-          input_usd_per_token: "0.00001", // $0.01 per 1K tokens
-          output_usd_per_token: "0.00002", // $0.02 per 1K tokens
-          effective_at: new Date().toISOString(),
-        };
+        // Get pricing from provider registry and calculate cost
+        const pricing = services.providerRegistry.getModelPricing(
+          decision.selected_model,
+        );
         const usage = {
           request_id: requestId,
           model_id: decision.selected_model,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,7 @@
 import Fastify from "fastify";
 import { registerRoutes } from "../src/gateway/routes.js";
 import { createProviderRegistry } from "../src/provider/registry.js";
+import { OpenAIAdapter } from "../src/provider/openai.adapter.js";
 import { createChallengeService } from "../src/x402/challenge.service.js";
 import {
   createPaymentVerifyService,
@@ -149,6 +150,14 @@ export function buildTestApp(overrides: Partial<ServiceContainer> = {}) {
   const app = Fastify({ logger: false });
 
   const providerRegistry = createProviderRegistry();
+
+  // Register test models with pricing
+  providerRegistry.register("openai/gpt-4o", new OpenAIAdapter("test-key"), {
+    input_usd_per_token: "0.00001",
+    output_usd_per_token: "0.00003",
+    effective_at: new Date().toISOString(),
+  });
+
   const ledgerService = createLedgerService();
   const traceService = createTraceService();
 
@@ -190,6 +199,14 @@ export function buildMockedTestApp(options?: {
   routerLatencyMs?: number;
 }): { app: ReturnType<typeof buildTestApp>; services: ServiceContainer } {
   const providerRegistry = createProviderRegistry();
+
+  // Register test models with pricing
+  providerRegistry.register("openai/gpt-4o", new OpenAIAdapter("test-key"), {
+    input_usd_per_token: "0.00001",
+    output_usd_per_token: "0.00003",
+    effective_at: new Date().toISOString(),
+  });
+
   const ledgerService = createLedgerService();
   const traceService = createTraceService();
   const replayService = createMockReplayService();

--- a/test/integration/flow.test.ts
+++ b/test/integration/flow.test.ts
@@ -645,7 +645,7 @@ describe("End-to-End Integration Flow", () => {
   });
 
   describe("Model Catalog", () => {
-    it("should return empty model catalog", async () => {
+    it("should return registered models", async () => {
       const { app } = buildMockedTestApp();
 
       const response = await app.inject({
@@ -656,7 +656,9 @@ describe("End-to-End Integration Flow", () => {
       expect(response.statusCode).toBe(200);
       const body = response.json();
       expect(body).toHaveProperty("data");
-      expect(body.data).toEqual([]);
+      expect(body.data.length).toBeGreaterThan(0);
+      expect(body.data[0]).toHaveProperty("id");
+      expect(body.data[0]).toHaveProperty("pricing");
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes SI-P1-001 (P1) from code audit (Issue #37):

### Issue Fixed

| Issue | Priority | Description | Status |
|-------|----------|-------------|--------|
| SI-P1-001 | 🟡 P1 | Remove hardcoded pricing, use dynamic pricing from registry | ✅ Fixed |

### Changes

**1. src/gateway/routes.ts**
- Replace hardcoded pricing object with `providerRegistry.getModelPricing()`
- Pricing now dynamically fetched based on selected model

**2. test/helpers.ts**
- Register test model `openai/gpt-4o` with pricing in mock registry
- Import `OpenAIAdapter` for test model registration

**3. test/integration/flow.test.ts**
- Update model catalog test: expect non-empty list instead of empty

### Testing

```bash
$ pnpm typecheck
✅ PASS - No TypeScript errors

$ pnpm test test/integration/flow.test.ts
✅ PASS - 15/15 tests
```

### PR Size

| Metric | Value | Constraint | Status |
|--------|-------|------------|--------|
| Files changed | 1 src + 2 test | ≤3 src files | ✅ |
| Lines changed | +25/-8 | ≤200 | ✅ |

---

**Next**: After merge, proceed to P6-PR4 (MeterService empty implementation)