### PR TITLE
fix(P6-PR5): Cleanup lint warnings + add memory storage annotations

### DIFF
--- a/src/audit/trace.service.ts
+++ b/src/audit/trace.service.ts
@@ -138,7 +138,10 @@ export interface ITraceService {
 export function createTraceService(deps?: TraceServiceDeps): ITraceService {
   const { log } = deps || {};
 
-  // In-memory storage for testing (will be replaced with database in production)
+  /**
+   * In-memory storage for MVP stage.
+   * Production environment must migrate to PostgreSQL for persistence.
+   */
   const traces = new Map<string, CompleteTrace>();
 
   return {

--- a/src/billing/ledger.service.ts
+++ b/src/billing/ledger.service.ts
@@ -129,7 +129,10 @@ export function createLedgerService(deps?: Partial<LedgerServiceDeps>): ILedgerS
     log,
   } = deps || {};
 
-  // In-memory storage for testing (will be replaced with database in production)
+  /**
+   * In-memory storage for MVP stage.
+   * Production environment must migrate to PostgreSQL for persistence.
+   */
   const ledgerStore = new Map<string, LedgerEntry>();
   const requestIndex = new Map<string, string>(); // request_id -> entry_id
   const quoteIndex = new Map<string, string>();   // quote_id -> entry_id

--- a/test/perf/load.test.ts
+++ b/test/perf/load.test.ts
@@ -160,24 +160,41 @@ describe("Performance Load Tests", () => {
           sortedLatencies[Math.floor(sortedLatencies.length * 0.99)];
 
         // Log performance metrics
+        // eslint-disable-next-line no-console
         console.log("\n========== Performance Test Results ==========");
+        // eslint-disable-next-line no-console
         console.log(`Duration: ${(Date.now() - startTime) / 1000}s`);
+        // eslint-disable-next-line no-console
         console.log(`Total Requests: ${totalRequests}`);
+        // eslint-disable-next-line no-console
         console.log(`Successful Requests: ${successfulRequests}`);
+        // eslint-disable-next-line no-console
         console.log(`Failed Requests: ${failedRequests}`);
+        // eslint-disable-next-line no-console
         console.log(`Error Rate: ${(errorRate * 100).toFixed(2)}%`);
+        // eslint-disable-next-line no-console
         console.log(`Target Error Rate: <${MAX_ERROR_RATE * 100}%`);
+        // eslint-disable-next-line no-console
         console.log(`\nLatency Metrics:`);
+        // eslint-disable-next-line no-console
         console.log(`  Min: ${minLatency}ms`);
+        // eslint-disable-next-line no-console
         console.log(`  Avg: ${avgLatency.toFixed(2)}ms`);
+        // eslint-disable-next-line no-console
         console.log(`  Max: ${maxLatency}ms`);
+        // eslint-disable-next-line no-console
         console.log(`  P50: ${p50Latency}ms`);
+        // eslint-disable-next-line no-console
         console.log(`  P95: ${p95Latency}ms`);
+        // eslint-disable-next-line no-console
         console.log(`  P99: ${p99Latency}ms`);
+        // eslint-disable-next-line no-console
         console.log(`Target RPS: ${TARGET_RPS}`);
+        // eslint-disable-next-line no-console
         console.log(
           `Actual RPS: ${(totalRequests / ((Date.now() - startTime) / 1000)).toFixed(2)}`,
         );
+        // eslint-disable-next-line no-console
         console.log("==============================================\n");
 
         // Assertions
@@ -281,12 +298,19 @@ describe("Performance Load Tests", () => {
         const avgLatency =
           results.reduce((a, r) => a + r.latencyMs, 0) / totalRequests;
 
+        // eslint-disable-next-line no-console
         console.log("\n========== Burst Test Results ==========");
+        // eslint-disable-next-line no-console
         console.log(`Duration: ${BURST_DURATION_MS / 1000}s`);
+        // eslint-disable-next-line no-console
         console.log(`Total Requests: ${totalRequests}`);
+        // eslint-disable-next-line no-console
         console.log(`Successful: ${successfulRequests}`);
+        // eslint-disable-next-line no-console
         console.log(`Error Rate: ${(errorRate * 100).toFixed(2)}%`);
+        // eslint-disable-next-line no-console
         console.log(`Avg Latency: ${avgLatency.toFixed(2)}ms`);
+        // eslint-disable-next-line no-console
         console.log("========================================\n");
 
         expect(totalRequests).toBeGreaterThan(0);
@@ -433,13 +457,21 @@ describe("Performance Load Tests", () => {
         const successfulRequests = results.filter((r) => r.success).length;
         const duplicateRequests = duplicateResults.length;
 
+        // eslint-disable-next-line no-console
         console.log("\n========== Idempotency Test Results ==========");
+        // eslint-disable-next-line no-console
         console.log(`Total Requests: ${results.length}`);
+        // eslint-disable-next-line no-console
         console.log(`Successful: ${successfulRequests}`);
+        // eslint-disable-next-line no-console
         console.log(`First-time Requests: ${idempotencyKeyInfo.size}`);
+        // eslint-disable-next-line no-console
         console.log(`Duplicate Requests: ${duplicateRequests}`);
+        // eslint-disable-next-line no-console
         console.log(`All Duplicate request_id Match: ${allDuplicatesMatch}`);
+        // eslint-disable-next-line no-console
         console.log(`Ledger Entries Created: ${ledgerCount}`);
+        // eslint-disable-next-line no-console
         console.log("==============================================\n");
 
         // Fix: Verify all duplicate requests have matching request_id


### PR DESCRIPTION
## Summary
- Fix SI-P2-001: Add eslint-disable to 32 console.log in load.test.ts
- Fix SI-P2-002: Add JSDoc annotations to in-memory stores

## Changes
- **test/perf/load.test.ts**: Add eslint-disable-next-line no-console to all console.log statements
- **src/audit/trace.service.ts**: Add JSDoc to traces Map
- **src/billing/ledger.service.ts**: Add JSDoc to ledgerStore Map

## Issues Fixed
- SI-P2-001: 32 lint warnings (console.log)
- SI-P2-002: Memory storage annotations missing

## Test Results
- Functional: 175/177 passed (2 unrelated simulation tests)

## Note
This is the **final PR** for P6 stage. Once merged, all 32 PRs will be complete!