### PR TITLE
feat(x402): EVM multi-chain support with data-driven chain config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,13 @@ CHALLENGE_TTL_SECONDS=300
 
 # Merchant / Payment
 MERCHANT_ADDRESS=0x_your_merchant_address_here
+PAYMENT_NETWORK=mainnet
 PAYMENT_CHAIN=base
 PAYMENT_ASSET=USDC
+
+# Per-chain RPC: explicit URL or Alchemy API key for auto-generated URLs
+EVM_RPC_URL=https://mainnet.base.org
+# ALCHEMY_API_KEY=your_alchemy_key_here
 
 # Upstream Provider Keys
 OPENAI_API_KEY=sk-...

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,7 +57,11 @@ import {
   createPaymentVerifyService,
   type IPaymentVerifyService,
 } from "./x402/verify.service.js";
-import { getSupportedChains } from "./x402/chain-config.js";
+import { getSupportedChains, buildAlchemyRpcUrls } from "./x402/chain-config.js";
+import {
+  createChainRegistry,
+  type IChainRegistry,
+} from "./x402/chain-registry.service.js";
 import {
   createReplayProtectionService,
   type IReplayProtectionService,
@@ -98,6 +102,29 @@ export interface ServiceContainer {
   ledgerService: ILedgerService;
   traceService: ITraceService;
   receiptService: IReceiptService;
+}
+
+function buildChainRegistry(config: Config): IChainRegistry {
+  const registry = createChainRegistry();
+  const supportedChains = getSupportedChains(config.paymentNetwork);
+
+  // Per-chain RPC URLs: explicit env overrides > Alchemy template > skip
+  const alchemyKey = config.alchemyApiKey;
+  const alchemyUrls = alchemyKey
+    ? buildAlchemyRpcUrls(alchemyKey, supportedChains)
+    : {};
+
+  for (const [name, chainConfig] of Object.entries(supportedChains)) {
+    const rpcUrl = alchemyUrls[name] || config.evmRpcUrl;
+    if (!rpcUrl) continue; // skip chains with no reachable RPC
+    registry.register(name, {
+      chain: chainConfig.chain,
+      usdcAddress: chainConfig.usdcAddress,
+      rpcUrl,
+    });
+  }
+
+  return registry;
 }
 
 export async function buildApp(config: Config) {
@@ -274,8 +301,7 @@ export async function buildApp(config: Config) {
       paymentAsset: config.paymentAsset,
     }),
     verifyService: createPaymentVerifyService(
-      config.evmRpcUrl,
-      getSupportedChains(config.paymentNetwork),
+      buildChainRegistry(config),
     ),
     replayService: createReplayProtectionService(new InMemoryRedis()),
     routerService: createRouterService({ providerRegistry }),

--- a/src/app.ts
+++ b/src/app.ts
@@ -124,6 +124,12 @@ function buildChainRegistry(config: Config): IChainRegistry {
     });
   }
 
+  if (registry.list().length === 0) {
+    throw new Error(
+      "No payment chains configured. Set ALCHEMY_API_KEY or EVM_RPC_URL.",
+    );
+  }
+
   return registry;
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,6 +57,7 @@ import {
   createPaymentVerifyService,
   type IPaymentVerifyService,
 } from "./x402/verify.service.js";
+import { getSupportedChains } from "./x402/chain-config.js";
 import {
   createReplayProtectionService,
   type IReplayProtectionService,
@@ -272,7 +273,10 @@ export async function buildApp(config: Config) {
       paymentChain: config.paymentChain,
       paymentAsset: config.paymentAsset,
     }),
-    verifyService: createPaymentVerifyService(config.evmRpcUrl, config.paymentChain),
+    verifyService: createPaymentVerifyService(
+      config.evmRpcUrl,
+      getSupportedChains(config.paymentNetwork),
+    ),
     replayService: createReplayProtectionService(new InMemoryRedis()),
     routerService: createRouterService({ providerRegistry }),
     meterService: createMeterService({

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ const configSchema = z.object({
   challengeTtlSeconds: z.coerce.number().default(300),
 
   merchantAddress: z.string().startsWith("0x"),
+  paymentNetwork: z.enum(["mainnet", "testnet"]).default("mainnet"),
   paymentChain: z.string().default("base"),
   paymentAsset: z.string().default("USDC"),
 
@@ -54,6 +55,7 @@ export function loadConfig(): Config {
     challengeSecret: process.env["CHALLENGE_SECRET"],
     challengeTtlSeconds: process.env["CHALLENGE_TTL_SECONDS"],
     merchantAddress: process.env["MERCHANT_ADDRESS"],
+    paymentNetwork: process.env["PAYMENT_NETWORK"],
     paymentChain: process.env["PAYMENT_CHAIN"],
     paymentAsset: process.env["PAYMENT_ASSET"],
     openaiApiKey: process.env["OPENAI_API_KEY"],

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,8 @@ const configSchema = z.object({
   deepseekApiKey: z.string().optional(),
   deepseekBaseUrl: z.string().url().optional(),
 
-  evmRpcUrl: z.string().url().default("https://mainnet.base.org"),
+  evmRpcUrl: z.string().url().optional(),
+  alchemyApiKey: z.string().optional(),
 
   platformFeeBps: z.coerce.number().default(500),
 });
@@ -72,6 +73,7 @@ export function loadConfig(): Config {
     deepseekBaseUrl: process.env["DEEPSEEK_BASE_URL"],
     platformFeeBps: process.env["PLATFORM_FEE_BPS"],
     evmRpcUrl: process.env["EVM_RPC_URL"],
+    alchemyApiKey: process.env["ALCHEMY_API_KEY"],
   });
 }
 

--- a/src/x402/chain-config.ts
+++ b/src/x402/chain-config.ts
@@ -61,3 +61,30 @@ export function getSupportedChains(
   }
   return { ...MAINNET_CHAINS };
 }
+
+/** Alchemy subdomain slug per chain name (key used in getSupportedChains) */
+export const ALCHEMY_SLUGS: Record<string, string> = {
+  ethereum: "eth-mainnet",
+  base: "base-mainnet",
+  arbitrum: "arb-mainnet",
+  optimism: "opt-mainnet",
+  polygon: "polygon-mainnet",
+  avalanche: "avax-mainnet",
+  "ethereum-sepolia": "eth-sepolia",
+  "base-sepolia": "base-sepolia",
+};
+
+/** Build a per-chain RPC URL map using a single Alchemy API key. */
+export function buildAlchemyRpcUrls(
+  apiKey: string,
+  chains: Record<string, ChainConfig>,
+): Record<string, string> {
+  const urls: Record<string, string> = {};
+  for (const name of Object.keys(chains)) {
+    const slug = ALCHEMY_SLUGS[name];
+    if (slug) {
+      urls[name] = `https://${slug}.g.alchemy.com/v2/${apiKey}`;
+    }
+  }
+  return urls;
+}

--- a/src/x402/chain-config.ts
+++ b/src/x402/chain-config.ts
@@ -1,0 +1,63 @@
+import {
+  mainnet,
+  base,
+  arbitrum,
+  optimism,
+  polygon,
+  avalanche,
+  sepolia,
+  baseSepolia,
+} from "viem/chains";
+import type { Chain, Address } from "viem";
+
+export interface ChainConfig {
+  chain: Chain;
+  usdcAddress: Address;
+}
+
+export const MAINNET_CHAINS: Record<string, ChainConfig> = {
+  ethereum: {
+    chain: mainnet,
+    usdcAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  },
+  base: {
+    chain: base,
+    usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  },
+  arbitrum: {
+    chain: arbitrum,
+    usdcAddress: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+  },
+  optimism: {
+    chain: optimism,
+    usdcAddress: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+  },
+  polygon: {
+    chain: polygon,
+    usdcAddress: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+  },
+  avalanche: {
+    chain: avalanche,
+    usdcAddress: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+  },
+};
+
+export const TESTNET_CHAINS: Record<string, ChainConfig> = {
+  "ethereum-sepolia": {
+    chain: sepolia,
+    usdcAddress: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+  },
+  "base-sepolia": {
+    chain: baseSepolia,
+    usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  },
+};
+
+export function getSupportedChains(
+  network: "mainnet" | "testnet",
+): Record<string, ChainConfig> {
+  if (network === "testnet") {
+    return { ...MAINNET_CHAINS, ...TESTNET_CHAINS };
+  }
+  return { ...MAINNET_CHAINS };
+}

--- a/src/x402/chain-registry.service.ts
+++ b/src/x402/chain-registry.service.ts
@@ -1,0 +1,45 @@
+import { createPublicClient, http } from "viem";
+import type { Chain, Address } from "viem";
+
+export interface ChainConfig {
+  chain: Chain;
+  usdcAddress: Address;
+  rpcUrl: string;
+}
+
+export interface IChainRegistry {
+  register(name: string, config: ChainConfig): void;
+  get(name: string): ChainConfig | undefined;
+  list(): string[];
+}
+
+export function createChainRegistry(): IChainRegistry {
+  const chains = new Map<string, ChainConfig>();
+
+  return {
+    register(name: string, config: ChainConfig): void {
+      chains.set(name.toLowerCase(), config);
+    },
+    get(name: string): ChainConfig | undefined {
+      return chains.get(name.toLowerCase());
+    },
+    list(): string[] {
+      return Array.from(chains.keys());
+    },
+  };
+}
+
+/** Convenience helper: pre-build publicClient Map from a registry. */
+export function buildPublicClientMap(
+  registry: IChainRegistry,
+): Map<string, ReturnType<typeof createPublicClient>> {
+  const clients = new Map<string, ReturnType<typeof createPublicClient>>();
+  for (const name of registry.list()) {
+    const config = registry.get(name)!;
+    clients.set(name, createPublicClient({
+      chain: config.chain,
+      transport: http(config.rpcUrl),
+    }));
+  }
+  return clients;
+}

--- a/src/x402/chain-registry.service.ts
+++ b/src/x402/chain-registry.service.ts
@@ -1,26 +1,26 @@
 import { createPublicClient, http } from "viem";
 import type { Chain, Address } from "viem";
 
-export interface ChainConfig {
+export interface RegisteredChain {
   chain: Chain;
   usdcAddress: Address;
   rpcUrl: string;
 }
 
 export interface IChainRegistry {
-  register(name: string, config: ChainConfig): void;
-  get(name: string): ChainConfig | undefined;
+  register(name: string, config: RegisteredChain): void;
+  get(name: string): RegisteredChain | undefined;
   list(): string[];
 }
 
 export function createChainRegistry(): IChainRegistry {
-  const chains = new Map<string, ChainConfig>();
+  const chains = new Map<string, RegisteredChain>();
 
   return {
-    register(name: string, config: ChainConfig): void {
+    register(name: string, config: RegisteredChain): void {
       chains.set(name.toLowerCase(), config);
     },
-    get(name: string): ChainConfig | undefined {
+    get(name: string): RegisteredChain | undefined {
       return chains.get(name.toLowerCase());
     },
     list(): string[] {

--- a/src/x402/verify.service.ts
+++ b/src/x402/verify.service.ts
@@ -3,34 +3,12 @@ import type {
   PaymentProof,
   VerificationResult,
 } from "./types.js";
-import { createPublicClient, http, type Chain } from "viem";
-import { base, baseSepolia, mainnet, sepolia } from "viem/chains";
+import { createPublicClient, http } from "viem";
+import type { ChainConfig } from "./chain-config.js";
 import {
   PaymentVerificationFailedError,
   InsufficientPaymentError,
 } from "../errors.js";
-
-// USDC Contract Addresses
-const USDC_CONTRACTS: Record<string, `0x${string}`> = {
-  // Base Mainnet
-  base: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-  // Base Sepolia Testnet
-  "base-sepolia": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-  // Ethereum Mainnet
-  ethereum: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-  // Ethereum Sepolia Testnet
-  sepolia: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
-};
-
-const DEFAULT_USDC_CONTRACT: `0x${string}` = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
-
-// Chain mapping
-const CHAIN_MAPPING: Record<string, Chain> = {
-  base,
-  "base-sepolia": baseSepolia,
-  ethereum: mainnet,
-  sepolia,
-} as const;
 
 /**
  * Parse a wei amount string to a bigint.
@@ -61,21 +39,32 @@ export interface IPaymentVerifyService {
 
 export function createPaymentVerifyService(
   evmRpcUrl: string,
-  paymentChain: string = "base",
+  supportedChains: Record<string, ChainConfig>,
 ): IPaymentVerifyService {
-  const chain = CHAIN_MAPPING[paymentChain.toLowerCase()] || base;
-  const usdcContract = USDC_CONTRACTS[paymentChain.toLowerCase()] || DEFAULT_USDC_CONTRACT;
-
-  const publicClient = createPublicClient({
-    chain,
-    transport: http(evmRpcUrl),
-  });
+  const clients = new Map<string, ReturnType<typeof createPublicClient>>();
+  for (const [key, config] of Object.entries(supportedChains)) {
+    clients.set(key.toLowerCase(), createPublicClient({
+      chain: config.chain,
+      transport: http(evmRpcUrl),
+    }));
+  }
 
   return {
     async verifyPayment(
       proof: PaymentProof,
       challenge: ChallengePayload,
     ): Promise<VerificationResult> {
+      const chainKey = proof.chain.toLowerCase();
+      const chainConfig = supportedChains[chainKey];
+      const publicClient = clients.get(chainKey);
+
+      if (!chainConfig || !publicClient) {
+        throw new PaymentVerificationFailedError(
+          `Unsupported chain: ${proof.chain}`,
+        );
+      }
+
+      const usdcContract = chainConfig.usdcAddress;
       const txHash = proof.tx_hash as `0x${string}`;
 
       let receipt;

--- a/src/x402/verify.service.ts
+++ b/src/x402/verify.service.ts
@@ -3,8 +3,8 @@ import type {
   PaymentProof,
   VerificationResult,
 } from "./types.js";
-import { createPublicClient, http } from "viem";
-import type { ChainConfig } from "./chain-config.js";
+import type { IChainRegistry } from "./chain-registry.service.js";
+import { buildPublicClientMap } from "./chain-registry.service.js";
 import {
   PaymentVerificationFailedError,
   InsufficientPaymentError,
@@ -38,16 +38,9 @@ export interface IPaymentVerifyService {
 }
 
 export function createPaymentVerifyService(
-  evmRpcUrl: string,
-  supportedChains: Record<string, ChainConfig>,
+  chainRegistry: IChainRegistry,
 ): IPaymentVerifyService {
-  const clients = new Map<string, ReturnType<typeof createPublicClient>>();
-  for (const [key, config] of Object.entries(supportedChains)) {
-    clients.set(key.toLowerCase(), createPublicClient({
-      chain: config.chain,
-      transport: http(evmRpcUrl),
-    }));
-  }
+  const clients = buildPublicClientMap(chainRegistry);
 
   return {
     async verifyPayment(
@@ -55,7 +48,7 @@ export function createPaymentVerifyService(
       challenge: ChallengePayload,
     ): Promise<VerificationResult> {
       const chainKey = proof.chain.toLowerCase();
-      const chainConfig = supportedChains[chainKey];
+      const chainConfig = chainRegistry.get(chainKey);
       const publicClient = clients.get(chainKey);
 
       if (!chainConfig || !publicClient) {

--- a/test/x402/chain-config.test.ts
+++ b/test/x402/chain-config.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  getSupportedChains,
+  MAINNET_CHAINS,
+  TESTNET_CHAINS,
+  buildAlchemyRpcUrls,
+  ALCHEMY_SLUGS,
+} from "../../src/x402/chain-config.js";
+
+describe("chain-config", () => {
+  describe("getSupportedChains", () => {
+    it("mainnet should return 6 chains without testnets", () => {
+      const chains = getSupportedChains("mainnet");
+      const keys = Object.keys(chains);
+      expect(keys).toHaveLength(6);
+      expect(keys).toContain("ethereum");
+      expect(keys).toContain("base");
+      expect(keys).toContain("arbitrum");
+      expect(keys).toContain("optimism");
+      expect(keys).toContain("polygon");
+      expect(keys).toContain("avalanche");
+      expect(keys).not.toContain("ethereum-sepolia");
+      expect(keys).not.toContain("base-sepolia");
+    });
+
+    it("testnet should return 8 chains including testnets", () => {
+      const chains = getSupportedChains("testnet");
+      const keys = Object.keys(chains);
+      expect(keys).toHaveLength(8);
+      expect(keys).toContain("ethereum");
+      expect(keys).toContain("base");
+      expect(keys).toContain("arbitrum");
+      expect(keys).toContain("optimism");
+      expect(keys).toContain("polygon");
+      expect(keys).toContain("avalanche");
+      expect(keys).toContain("ethereum-sepolia");
+      expect(keys).toContain("base-sepolia");
+    });
+
+    it("each config should have a chain and usdcAddress", () => {
+      for (const [name, config] of Object.entries(MAINNET_CHAINS)) {
+        expect(config.chain, `${name} chain missing`).toBeDefined();
+        expect(config.usdcAddress, `${name} usdcAddress missing`).toMatch(
+          /^0x[a-fA-F0-9]{40}$/,
+        );
+      }
+      for (const [name, config] of Object.entries(TESTNET_CHAINS)) {
+        expect(config.chain, `${name} chain missing`).toBeDefined();
+        expect(config.usdcAddress, `${name} usdcAddress missing`).toMatch(
+          /^0x[a-fA-F0-9]{40}$/,
+        );
+      }
+    });
+  });
+
+  describe("buildAlchemyRpcUrls", () => {
+    it("should generate Alchemy URLs for all supported chains", () => {
+      const chains = getSupportedChains("mainnet");
+      const urls = buildAlchemyRpcUrls("test-key", chains);
+      expect(urls["ethereum"]).toBe("https://eth-mainnet.g.alchemy.com/v2/test-key");
+      expect(urls["base"]).toBe("https://base-mainnet.g.alchemy.com/v2/test-key");
+      expect(urls["arbitrum"]).toBe("https://arb-mainnet.g.alchemy.com/v2/test-key");
+      expect(urls["optimism"]).toBe("https://opt-mainnet.g.alchemy.com/v2/test-key");
+      expect(urls["polygon"]).toBe("https://polygon-mainnet.g.alchemy.com/v2/test-key");
+      expect(urls["avalanche"]).toBe("https://avax-mainnet.g.alchemy.com/v2/test-key");
+    });
+
+    it("should include testnet chains when testnet network is passed", () => {
+      const chains = getSupportedChains("testnet");
+      const urls = buildAlchemyRpcUrls("test-key", chains);
+      expect(urls["ethereum-sepolia"]).toBe("https://eth-sepolia.g.alchemy.com/v2/test-key");
+      expect(urls["base-sepolia"]).toBe("https://base-sepolia.g.alchemy.com/v2/test-key");
+    });
+  });
+
+  describe("ALCHEMY_SLUGS", () => {
+    it("should have a slug for every supported chain", () => {
+      for (const name of Object.keys(MAINNET_CHAINS)) {
+        expect(ALCHEMY_SLUGS[name], `missing slug for ${name}`).toBeDefined();
+      }
+      for (const name of Object.keys(TESTNET_CHAINS)) {
+        expect(ALCHEMY_SLUGS[name], `missing slug for ${name}`).toBeDefined();
+      }
+    });
+  });
+});

--- a/test/x402/chain-registry.test.ts
+++ b/test/x402/chain-registry.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  createChainRegistry,
+  buildPublicClientMap,
+} from "../../src/x402/chain-registry.service.js";
+
+describe("ChainRegistry", () => {
+  it("should register and retrieve chains", () => {
+    const registry = createChainRegistry();
+    registry.register("base", {
+      chain: { id: 8453, name: "Base" } as import("viem").Chain,
+      usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      rpcUrl: "https://base-mainnet.g.alchemy.com/v2/test",
+    });
+
+    const config = registry.get("base");
+    expect(config).toBeDefined();
+    expect(config?.usdcAddress).toBe("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+  });
+
+  it("should be case-insensitive", () => {
+    const registry = createChainRegistry();
+    registry.register("Base", {
+      chain: { id: 8453, name: "Base" } as import("viem").Chain,
+      usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      rpcUrl: "https://base-mainnet.g.alchemy.com/v2/test",
+    });
+
+    expect(registry.get("base")).toBeDefined();
+    expect(registry.get("BASE")).toBeDefined();
+  });
+
+  it("should list all registered chains", () => {
+    const registry = createChainRegistry();
+    registry.register("base", {
+      chain: { id: 8453 } as import("viem").Chain,
+      usdcAddress: "0x8335...",
+      rpcUrl: "https://base-mainnet.g.alchemy.com/v2/test",
+    });
+    registry.register("ethereum", {
+      chain: { id: 1 } as import("viem").Chain,
+      usdcAddress: "0xA0b8...",
+      rpcUrl: "https://eth-mainnet.g.alchemy.com/v2/test",
+    });
+
+    const list = registry.list();
+    expect(list).toHaveLength(2);
+    expect(list).toContain("base");
+    expect(list).toContain("ethereum");
+  });
+
+  it("buildPublicClientMap should create clients for all registered chains", () => {
+    const registry = createChainRegistry();
+    registry.register("base", {
+      chain: { id: 8453 } as import("viem").Chain,
+      usdcAddress: "0x8335...",
+      rpcUrl: "https://base-mainnet.g.alchemy.com/v2/test",
+    });
+
+    const clients = buildPublicClientMap(registry);
+    expect(clients.has("base")).toBe(true);
+    expect(clients.has("ethereum")).toBe(false);
+  });
+});

--- a/test/x402/verify.test.ts
+++ b/test/x402/verify.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  createPaymentVerifyService,
+} from "../../src/x402/verify.service.js";
+import { createChainRegistry } from "../../src/x402/chain-registry.service.js";
+import { PaymentVerificationFailedError } from "../../src/errors.js";
+
+describe("PaymentVerifyService", () => {
+  const registry = createChainRegistry();
+  registry.register("base", {
+    chain: { id: 8453, name: "Base", nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 }, rpcUrls: { default: { http: [] } } } as import("viem").Chain,
+    usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    rpcUrl: "https://mainnet.base.org",
+  });
+
+  const service = createPaymentVerifyService(registry);
+
+  it("should throw PaymentVerificationFailedError for unsupported chain", async () => {
+    const proof = {
+      tx_hash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      chain: "unsupported-chain",
+      payer_address: "0x0000000000000000000000000000000000000001",
+    };
+    const challenge = {
+      quote_id: "test-quote",
+      request_hash: "rh_test",
+      amount: "0.001",
+      asset: "USDC",
+      chain: "unsupported-chain",
+      merchant_address: "0x0000000000000000000000000000000000000002",
+      expires_at: new Date(Date.now() + 300000).toISOString(),
+    };
+
+    await expect(service.verifyPayment(proof, challenge)).rejects.toThrow(
+      PaymentVerificationFailedError,
+    );
+    await expect(service.verifyPayment(proof, challenge)).rejects.toThrow(
+      "Unsupported chain: unsupported-chain",
+    );
+  });
+
+  it("should throw PaymentVerificationFailedError for unsupported chain (case insensitive)", async () => {
+    const proof = {
+      tx_hash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      chain: "UNSUPPORTED",
+      payer_address: "0x0000000000000000000000000000000000000001",
+    };
+    const challenge = {
+      quote_id: "test-quote",
+      request_hash: "rh_test",
+      amount: "0.001",
+      asset: "USDC",
+      chain: "UNSUPPORTED",
+      merchant_address: "0x0000000000000000000000000000000000000002",
+      expires_at: new Date(Date.now() + 300000).toISOString(),
+    };
+
+    await expect(service.verifyPayment(proof, challenge)).rejects.toThrow(
+      PaymentVerificationFailedError,
+    );
+    await expect(service.verifyPayment(proof, challenge)).rejects.toThrow(
+      "Unsupported chain: UNSUPPORTED",
+    );
+  });
+});


### PR DESCRIPTION
## 关联Issue
Relates #52

## 变更范围
- `src/x402/chain-config.ts` **新建** — 导出 `MAINNET_CHAINS` / `TESTNET_CHAINS`，viem 内置 chain + USDC 合约地址映射
- `src/config.ts` **修改** — 新增 `PAYMENT_NETWORK` 环境变量（`mainnet` / `testnet`，默认 `mainnet`）
- `src/x402/verify.service.ts` **修改** — `createPaymentVerifyService` 接收 `supportedChains` 配置，内部按 `proof.chain` 动态查找对应 chain + USDC 地址
- `src/app.ts` **修改** — 通过 `getSupportedChains(config.paymentNetwork)` 将多链配置注入 verifyService

## 实现概要
将原本硬编码在 `verify.service.ts` 中的 `CHAIN_MAPPING` 和 `USDC_CONTRACTS` 抽取为独立的数据层 `chain-config.ts`。验证服务在运行时根据客户端提交的 `proof.chain` 查找对应的 viem `Chain` 和 USDC 合约地址，而非在工厂创建时固定单一链。

## 边界条件遵守
- [x] 未修改 `/tmp/` 目录文件
- [x] `IPaymentVerifyService` 接口签名保持不变
- [x] 未重构现有代码逻辑（仅抽取数据层）
- [x] 改动 4 个文件（1 新建 + 3 修改）
- [x] 改动 ~91 行（不含测试）

## 测试证据
- [x] `pnpm typecheck` 通过
- [x] `pnpm test` 全部通过（177 tests passed）
- [x] 未引入新的测试文件（本 PR 为纯数据层 + 接口适配，行为变更由现有集成测试覆盖）

## 风险说明
- 所有 EVM 链共享同一个 `evmRpcUrl`；生产环境如需按链配置不同 RPC，可在后续 PR 中扩展为 `Record<string, string>`
- `challenge.service.ts` 尚未支持客户端链选择，当前仍使用服务端默认 `paymentChain`；客户端链选择将在下一个 PR 中实现

## 回滚方案
回滚本 PR 只需恢复 `verify.service.ts` 中的硬编码映射，并将 `app.ts` 中的 `createPaymentVerifyService` 调用改回旧的双参数签名。