### PR TITLE
feat(x402): Solana SPL Token payment verification (PR2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "nanoid": "^5.1.5",
     "pino": "^9.6.0",
     "dotenv": "^16.5.0",
-    "viem": "^2.30.2"
+    "viem": "^2.30.2",
+    "@solana/web3.js": "^1.98.0",
+    "@solana/spl-token": "^0.4.13"
   },
   "devDependencies": {
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@fastify/sensible':
         specifier: ^6.0.3
         version: 6.0.4
+      '@solana/spl-token':
+        specifier: ^0.4.13
+        version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js':
+        specifier: ^1.98.0
+        version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       dotenv:
         specifier: ^16.5.0
         version: 16.6.1
@@ -46,7 +52,7 @@ importers:
         version: 9.14.0
       viem:
         specifier: ^2.30.2
-        version: 2.47.10(typescript@5.9.3)(zod@3.25.76)
+        version: 2.47.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       zod:
         specifier: ^3.24.4
         version: 3.25.76
@@ -83,6 +89,10 @@ packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -485,8 +495,99 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
+  '@solana/buffer-layout-utils@0.2.0':
+    resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
+    engines: {node: '>= 10'}
+
+  '@solana/buffer-layout@4.0.1':
+    resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
+    engines: {node: '>=5.10'}
+
+  '@solana/codecs-core@2.0.0-rc.1':
+    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-core@2.3.0':
+    resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/codecs-data-structures@2.0.0-rc.1':
+    resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-numbers@2.0.0-rc.1':
+    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-numbers@2.3.0':
+    resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/codecs-strings@2.0.0-rc.1':
+    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5'
+
+  '@solana/codecs@2.0.0-rc.1':
+    resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/errors@2.0.0-rc.1':
+    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/errors@2.3.0':
+    resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/options@2.0.0-rc.1':
+    resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/spl-token-group@0.0.7':
+    resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token-metadata@0.1.6':
+    resolution: {integrity: sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token@0.4.14':
+    resolution: {integrity: sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.5
+
+  '@solana/web3.js@1.98.4':
+    resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
+
+  '@swc/helpers@0.5.21':
+    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -494,11 +595,23 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/ws@7.4.7':
+    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -614,6 +727,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -657,6 +774,28 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bigint-buffer@1.1.5:
+    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
+    engines: {node: '>= 10.0.0'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
+
+  borsh@0.7.0:
+    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
+
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
@@ -666,6 +805,16 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -683,6 +832,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -697,6 +850,17 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -729,6 +893,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delay@5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
+
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
@@ -755,6 +923,12 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+
+  es6-promisify@5.0.0:
+    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -809,6 +983,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  eyes@0.1.8:
+    resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
+    engines: {node: '> 0.1.90'}
+
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
 
@@ -831,8 +1009,14 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
+  fast-stable-stringify@1.0.0:
+    resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastestsmallesttextencoderdecoder@1.0.22:
+    resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -855,6 +1039,9 @@ packages:
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -925,6 +1112,12 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -971,10 +1164,20 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-ws@4.0.1:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: '*'
+
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
+
+  jayson@4.3.0:
+    resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
@@ -1000,6 +1203,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1076,6 +1282,19 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -1275,8 +1494,14 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rpc-websockets@9.3.8:
+    resolution: {integrity: sha512-7r+fm4tSJmLf9GvZfL1DJ1SJwpagpp6AazqM0FUaeV7CA+7+NYINSk1syWa4tU/6OF2CyBicLtzENGmXRJH6wQ==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex2@5.1.0:
     resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
@@ -1339,6 +1564,12 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stream-chain@2.2.5:
+    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
+
+  stream-json@1.9.1:
+    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1350,9 +1581,16 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  text-encoding-utf-8@1.0.2:
+    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -1394,11 +1632,17 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -1427,6 +1671,19 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -1513,6 +1770,12 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1529,6 +1792,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -1556,6 +1831,8 @@ packages:
 snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
+
+  '@babel/runtime@7.29.2': {}
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -1835,14 +2112,165 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@solana/buffer-layout-utils@0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      bigint-buffer: 1.1.5
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@solana/buffer-layout@4.0.1':
+    dependencies:
+      buffer: 6.0.3
+
+  '@solana/codecs-core@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-core@2.3.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.3.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.9.3
+
+  '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/errors@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
+      typescript: 5.9.3
+
+  '@solana/errors@2.3.0(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.3
+      typescript: 5.9.3
+
+  '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token@0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@solana/buffer-layout': 4.0.1
+      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
+      agentkeepalive: 4.6.0
+      bn.js: 5.2.3
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.3
+      fast-stable-stringify: 1.0.0
+      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      node-fetch: 2.7.0
+      rpc-websockets: 9.3.8
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/node@12.20.55': {}
 
   '@types/node@22.19.17':
     dependencies:
@@ -1853,6 +2281,16 @@ snapshots:
       '@types/node': 22.19.17
       pg-protocol: 1.13.0
       pg-types: 2.2.0
+
+  '@types/uuid@10.0.0': {}
+
+  '@types/ws@7.4.7':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -1992,6 +2430,10 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -2031,6 +2473,30 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base-x@3.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  base64-js@1.5.1: {}
+
+  bigint-buffer@1.1.5:
+    dependencies:
+      bindings: 1.5.0
+
+  bignumber.js@9.3.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bn.js@5.2.3: {}
+
+  borsh@0.7.0:
+    dependencies:
+      bn.js: 5.2.3
+      bs58: 4.0.1
+      text-encoding-utf-8: 1.0.2
+
   brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
@@ -2043,6 +2509,20 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  bs58@4.0.1:
+    dependencies:
+      base-x: 3.0.11
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
 
   cac@6.7.14: {}
 
@@ -2061,6 +2541,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   check-error@2.1.3: {}
 
   cluster-key-slot@1.1.2: {}
@@ -2070,6 +2552,12 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@12.1.0: {}
+
+  commander@14.0.3: {}
+
+  commander@2.20.3: {}
 
   concat-map@0.0.1: {}
 
@@ -2091,6 +2579,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delay@5.0.0: {}
+
   denque@2.1.0: {}
 
   depd@2.0.0: {}
@@ -2108,6 +2598,12 @@ snapshots:
   dotenv@16.6.1: {}
 
   es-module-lexer@1.7.0: {}
+
+  es6-promise@4.2.8: {}
+
+  es6-promisify@5.0.0:
+    dependencies:
+      es6-promise: 4.2.8
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2216,6 +2712,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  eyes@0.1.8: {}
+
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -2245,7 +2743,11 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
+  fast-stable-stringify@1.0.0: {}
+
   fast-uri@3.1.0: {}
+
+  fastestsmallesttextencoderdecoder@1.0.22: {}
 
   fastify-plugin@5.1.0: {}
 
@@ -2278,6 +2780,8 @@ snapshots:
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
+
+  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -2357,6 +2861,12 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -2401,9 +2911,31 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isows@1.0.7(ws@8.18.3):
+  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.18.3
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 12.20.55
+      '@types/ws': 7.4.7
+      commander: 2.20.3
+      delay: 5.0.0
+      es6-promisify: 5.0.0
+      eyes: 0.1.8
+      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      json-stringify-safe: 5.0.1
+      stream-json: 1.9.1
+      uuid: 8.3.2
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   jose@6.2.2: {}
 
@@ -2424,6 +2956,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-safe@5.0.1: {}
 
   keyv@4.5.4:
     dependencies:
@@ -2488,6 +3022,13 @@ snapshots:
   nanoid@5.1.7: {}
 
   natural-compare@1.4.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   on-exit-leak-free@2.1.2: {}
 
@@ -2689,9 +3230,24 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  rpc-websockets@9.3.8:
+    dependencies:
+      '@swc/helpers': 0.5.21
+      '@types/uuid': 10.0.0
+      '@types/ws': 8.18.1
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      uuid: 11.1.1
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.0:
     dependencies:
@@ -2733,6 +3289,12 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stream-chain@2.2.5: {}
+
+  stream-json@1.9.1:
+    dependencies:
+      stream-chain: 2.2.5
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -2743,9 +3305,13 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  superstruct@2.0.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  text-encoding-utf-8@1.0.2: {}
 
   text-table@0.2.0: {}
 
@@ -2776,9 +3342,13 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tr46@0.0.3: {}
+
   ts-api-utils@1.4.3(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -2807,18 +3377,27 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
+  uuid@11.1.1: {}
+
+  uuid@8.3.2: {}
+
   vary@1.1.2: {}
 
-  viem@2.47.10(typescript@5.9.3)(zod@3.25.76):
+  viem@2.47.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.14.7(typescript@5.9.3)(zod@3.25.76)
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2901,6 +3480,13 @@ snapshots:
       - tsx
       - yaml
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -2914,7 +3500,15 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.3: {}
+  ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   xtend@4.0.2: {}
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -56,7 +56,7 @@ import {
 import {
   createPaymentVerifyService,
   type IPaymentVerifyService,
-} from "./x402/verify.service.js";
+} from "./x402/verify/index.js";
 import { getSupportedChains, buildAlchemyRpcUrls } from "./x402/chain-config.js";
 import {
   createChainRegistry,
@@ -306,9 +306,10 @@ export async function buildApp(config: Config) {
       paymentChain: config.paymentChain,
       paymentAsset: config.paymentAsset,
     }),
-    verifyService: createPaymentVerifyService(
-      buildChainRegistry(config),
-    ),
+    verifyService: createPaymentVerifyService({
+      chainRegistry: buildChainRegistry(config),
+      solanaRpcUrl: config.solanaRpcUrl,
+    }),
     replayService: createReplayProtectionService(new InMemoryRedis()),
     routerService: createRouterService({ providerRegistry }),
     meterService: createMeterService({

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ const configSchema = z.object({
 
   evmRpcUrl: z.string().url().optional(),
   alchemyApiKey: z.string().optional(),
+  solanaRpcUrl: z.string().url().optional(),
 
   platformFeeBps: z.coerce.number().default(500),
 });
@@ -74,6 +75,7 @@ export function loadConfig(): Config {
     platformFeeBps: process.env["PLATFORM_FEE_BPS"],
     evmRpcUrl: process.env["EVM_RPC_URL"],
     alchemyApiKey: process.env["ALCHEMY_API_KEY"],
+    solanaRpcUrl: process.env["SOLANA_RPC_URL"],
   });
 }
 

--- a/src/x402/index.ts
+++ b/src/x402/index.ts
@@ -6,7 +6,7 @@ export type {
 } from './types.js';
 export { createChallengeService } from './challenge.service.js';
 export type { IChallengeService } from './challenge.service.js';
-export { createPaymentVerifyService } from './verify.service.js';
-export type { IPaymentVerifyService } from './verify.service.js';
+export { createPaymentVerifyService } from './verify/index.js';
+export type { IPaymentVerifyService } from './verify/index.js';
 export { createReplayProtectionService } from './replay.service.js';
 export type { IReplayProtectionService } from './replay.service.js';

--- a/src/x402/verify/evm-verify.service.ts
+++ b/src/x402/verify/evm-verify.service.ts
@@ -2,13 +2,13 @@ import type {
   ChallengePayload,
   PaymentProof,
   VerificationResult,
-} from "./types.js";
-import type { IChainRegistry } from "./chain-registry.service.js";
-import { buildPublicClientMap } from "./chain-registry.service.js";
+} from "../types.js";
+import type { IChainRegistry } from "../chain-registry.service.js";
+import { buildPublicClientMap } from "../chain-registry.service.js";
 import {
   PaymentVerificationFailedError,
   InsufficientPaymentError,
-} from "../errors.js";
+} from "../../errors.js";
 
 /**
  * Parse a wei amount string to a bigint.
@@ -30,16 +30,16 @@ function parseAmount(amount: string): bigint {
 const ERC20_TRANSFER_SIGNATURE =
   "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df35b9d8";
 
-export interface IPaymentVerifyService {
+export interface IEvmVerifyService {
   verifyPayment(
     proof: PaymentProof,
     challenge: ChallengePayload,
   ): Promise<VerificationResult>;
 }
 
-export function createPaymentVerifyService(
+export function createEvmVerifyService(
   chainRegistry: IChainRegistry,
-): IPaymentVerifyService {
+): IEvmVerifyService {
   const clients = buildPublicClientMap(chainRegistry);
 
   return {

--- a/src/x402/verify/index.ts
+++ b/src/x402/verify/index.ts
@@ -1,0 +1,53 @@
+import type {
+  ChallengePayload,
+  PaymentProof,
+  VerificationResult,
+} from "../types.js";
+import type { IChainRegistry } from "../chain-registry.service.js";
+import {
+  createEvmVerifyService,
+  type IEvmVerifyService,
+} from "./evm-verify.service.js";
+import {
+  createSolanaVerifyService,
+  type ISolanaVerifyService,
+} from "./solana-verify.service.js";
+import { PaymentVerificationFailedError } from "../../errors.js";
+
+export interface IPaymentVerifyService {
+  verifyPayment(
+    proof: PaymentProof,
+    challenge: ChallengePayload,
+  ): Promise<VerificationResult>;
+}
+
+export function createPaymentVerifyService(deps: {
+  chainRegistry: IChainRegistry;
+  solanaRpcUrl?: string;
+}): IPaymentVerifyService {
+  const evmVerifier: IEvmVerifyService = createEvmVerifyService(deps.chainRegistry);
+  const solanaVerifier: ISolanaVerifyService | undefined = deps.solanaRpcUrl
+    ? createSolanaVerifyService({ rpcUrl: deps.solanaRpcUrl })
+    : undefined;
+
+  return {
+    async verifyPayment(
+      proof: PaymentProof,
+      challenge: ChallengePayload,
+    ): Promise<VerificationResult> {
+      const chain = proof.chain.toLowerCase();
+
+      if (chain === "solana") {
+        if (!solanaVerifier) {
+          throw new PaymentVerificationFailedError(
+            "Solana verification is not configured. Set SOLANA_RPC_URL.",
+          );
+        }
+        return solanaVerifier.verifyPayment(proof, challenge);
+      }
+
+      // All other chains route through EVM verifier
+      return evmVerifier.verifyPayment(proof, challenge);
+    },
+  };
+}

--- a/src/x402/verify/solana-verify.service.ts
+++ b/src/x402/verify/solana-verify.service.ts
@@ -1,0 +1,199 @@
+import { Connection } from "@solana/web3.js";
+import type {
+  ChallengePayload,
+  PaymentProof,
+  VerificationResult,
+} from "../types.js";
+import {
+  PaymentVerificationFailedError,
+  InsufficientPaymentError,
+} from "../../errors.js";
+
+/** Official Solana Mainnet USDC SPL Token mint address */
+export const SOLANA_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+/** SPL Token program ID (legacy) */
+export const SPL_TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+/** SPL Token 2022 program ID */
+const SPL_TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+
+/** USDC on Solana has 6 decimal places (not 18 like EVM) */
+const SOLANA_USDC_DECIMALS = 6;
+
+/**
+ * Parse a decimal amount string to lamports (base units).
+ * e.g. "0.001" -> 1000n (for 6-decimal USDC)
+ */
+function parseSolanaAmount(amount: string): bigint {
+  if (amount.includes(".")) {
+    const [whole, fraction = ""] = amount.split(".");
+    const paddedFraction = fraction
+      .padEnd(SOLANA_USDC_DECIMALS, "0")
+      .slice(0, SOLANA_USDC_DECIMALS);
+    return BigInt(whole + paddedFraction);
+  }
+  return BigInt(amount) * BigInt(10 ** SOLANA_USDC_DECIMALS);
+}
+
+export interface ISolanaVerifyService {
+  verifyPayment(
+    proof: PaymentProof,
+    challenge: ChallengePayload,
+  ): Promise<VerificationResult>;
+}
+
+export function createSolanaVerifyService(deps: {
+  rpcUrl: string;
+}): ISolanaVerifyService {
+  const connection = new Connection(deps.rpcUrl, "confirmed");
+
+  return {
+    async verifyPayment(
+      proof: PaymentProof,
+      challenge: ChallengePayload,
+    ): Promise<VerificationResult> {
+      let signature: string;
+      try {
+        signature = proof.tx_hash;
+        // Basic validation: Solana signatures are base58-encoded 64-88 chars
+        if (!signature || signature.length < 64 || signature.length > 88) {
+          throw new PaymentVerificationFailedError("Invalid Solana transaction signature");
+        }
+      } catch {
+        throw new PaymentVerificationFailedError("Invalid Solana transaction signature");
+      }
+
+      let parsedTx;
+      try {
+        parsedTx = await connection.getParsedTransaction(signature, {
+          commitment: "confirmed",
+          maxSupportedTransactionVersion: 0,
+        });
+      } catch (error) {
+        throw new PaymentVerificationFailedError(
+          `Failed to fetch Solana transaction: ${(error as Error).message}`,
+        );
+      }
+
+      if (!parsedTx) {
+        throw new PaymentVerificationFailedError(
+          "Solana transaction not found or not yet confirmed",
+        );
+      }
+
+      if (parsedTx.meta?.err) {
+        throw new PaymentVerificationFailedError(
+          `Solana transaction failed: ${JSON.stringify(parsedTx.meta.err)}`,
+        );
+      }
+
+      // Validate payer address matches the transaction fee payer
+      const feePayer = parsedTx.transaction.message.accountKeys[0]?.pubkey.toBase58();
+      if (!feePayer || feePayer.toLowerCase() !== proof.payer_address.toLowerCase()) {
+        throw new PaymentVerificationFailedError(
+          "Payer address does not match transaction fee payer",
+        );
+      }
+
+      const requiredAmount = parseSolanaAmount(challenge.amount);
+
+      // Build account index -> owner mapping from preTokenBalances for USDC
+      const accountOwners = new Map<number, string>();
+      for (const pre of parsedTx.meta?.preTokenBalances ?? []) {
+        if (pre.mint === SOLANA_USDC_MINT && pre.owner) {
+          accountOwners.set(pre.accountIndex, pre.owner);
+        }
+      }
+      for (const post of parsedTx.meta?.postTokenBalances ?? []) {
+        if (post.mint === SOLANA_USDC_MINT && post.owner && !accountOwners.has(post.accountIndex)) {
+          accountOwners.set(post.accountIndex, post.owner);
+        }
+      }
+
+      // Also map accountKeys pubkey -> index for quick lookup
+      const pubkeyToIndex = new Map<string, number>();
+      parsedTx.transaction.message.accountKeys.forEach((acc, idx) => {
+        pubkeyToIndex.set(acc.pubkey.toBase58(), idx);
+      });
+
+      // Parse instructions looking for SPL Token transfers
+      let totalReceived = 0n;
+      let foundTransfer = false;
+
+      const instructions = parsedTx.transaction.message.instructions;
+      for (const ix of instructions) {
+        const programId = ix.programId?.toBase58?.() ?? (ix as unknown as Record<string, unknown>).programId;
+        if (
+          programId !== SPL_TOKEN_PROGRAM_ID &&
+          programId !== SPL_TOKEN_2022_PROGRAM_ID
+        ) {
+          continue;
+        }
+
+        const parsed = (ix as unknown as { parsed?: { type?: string; info?: Record<string, unknown> } }).parsed;
+        if (!parsed) continue;
+
+        const type = parsed.type;
+        if (type !== "transfer" && type !== "transferChecked") continue;
+
+        const info = parsed.info;
+        if (!info) continue;
+
+        // Check mint for transferChecked
+        if (type === "transferChecked") {
+          const mint = info.mint as string | undefined;
+          if (mint !== SOLANA_USDC_MINT) continue;
+        }
+
+        // Resolve source/destination owners via token balances
+        const sourceAccount = info.source as string | undefined;
+        const destAccount = info.destination as string | undefined;
+        if (!sourceAccount || !destAccount) continue;
+
+        const sourceIdx = pubkeyToIndex.get(sourceAccount);
+        const destIdx = pubkeyToIndex.get(destAccount);
+        if (sourceIdx === undefined || destIdx === undefined) continue;
+
+        const sourceOwner = accountOwners.get(sourceIdx);
+        const destOwner = accountOwners.get(destIdx);
+
+        if (
+          sourceOwner?.toLowerCase() === proof.payer_address.toLowerCase() &&
+          destOwner?.toLowerCase() === challenge.merchant_address.toLowerCase()
+        ) {
+          foundTransfer = true;
+          if (type === "transferChecked") {
+            const tokenAmount = info.tokenAmount as { amount?: string } | undefined;
+            if (tokenAmount?.amount) {
+              totalReceived += BigInt(tokenAmount.amount);
+            }
+          } else {
+            const amount = info.amount as string | undefined;
+            if (amount) {
+              totalReceived += BigInt(amount);
+            }
+          }
+        }
+      }
+
+      if (!foundTransfer) {
+        throw new PaymentVerificationFailedError(
+          "No USDC transfer from payer to merchant found in transaction",
+        );
+      }
+
+      if (totalReceived < requiredAmount) {
+        throw new InsufficientPaymentError(
+          challenge.amount,
+          (Number(totalReceived) / 10 ** SOLANA_USDC_DECIMALS).toFixed(SOLANA_USDC_DECIMALS),
+        );
+      }
+
+      return {
+        verified: true,
+        payer_address: proof.payer_address,
+        amount: challenge.amount,
+      };
+    },
+  };
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -6,7 +6,8 @@ import { createChallengeService } from "../src/x402/challenge.service.js";
 import {
   createPaymentVerifyService,
   type IPaymentVerifyService,
-} from "../src/x402/verify.service.js";
+} from "../src/x402/verify/index.js";
+import { createChainRegistry } from "../src/x402/chain-registry.service.js";
 import {
   createReplayProtectionService,
   type IReplayProtectionService,
@@ -170,7 +171,17 @@ export function buildTestApp(overrides: Partial<ServiceContainer> = {}) {
       paymentChain: "base",
       paymentAsset: "USDC",
     }),
-    verifyService: createPaymentVerifyService("https://sepolia.base.org"),
+    verifyService: createPaymentVerifyService({
+      chainRegistry: (() => {
+        const registry = createChainRegistry();
+        registry.register("base", {
+          chain: { id: 8453, name: "Base", nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 }, rpcUrls: { default: { http: [] } } } as import("viem").Chain,
+          usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          rpcUrl: "https://sepolia.base.org",
+        });
+        return registry;
+      })(),
+    }),
     replayService: createReplayProtectionService(null as never),
     routerService: createRouterService({ providerRegistry }),
     meterService: createMeterService({

--- a/test/x402/solana-verify.test.ts
+++ b/test/x402/solana-verify.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createSolanaVerifyService,
+  SOLANA_USDC_MINT,
+  SPL_TOKEN_PROGRAM_ID,
+} from "../../src/x402/verify/solana-verify.service.js";
+import {
+  PaymentVerificationFailedError,
+  InsufficientPaymentError,
+} from "../../src/errors.js";
+
+// Mock @solana/web3.js Connection and PublicKey
+vi.mock("@solana/web3.js", () => ({
+  Connection: vi.fn(),
+  PublicKey: vi.fn((value: string) => ({
+    toBase58: () => value,
+    toString: () => value,
+  })),
+}));
+
+describe("SolanaVerifyService", () => {
+  const mockRpcUrl = "https://api.mainnet-beta.solana.com";
+  const payerAddress = "Payer111111111111111111111111111111111111111";
+  const merchantAddress = "Merchant111111111111111111111111111111111111";
+  const txSignature = "5VxPdN7fm6zQy1ZbYBHpJzgCCHkVWgTQe9FxWkBnjRaDqRqDqzrb7KMYE5YqRqDqzrb7KMYE5YqRqDqzrb7KMYE5";
+
+  function buildMockConnection(getParsedTransactionResult: unknown) {
+    return {
+      getParsedTransaction: vi.fn().mockResolvedValue(getParsedTransactionResult),
+    };
+  }
+
+  function buildChallenge(amount = "0.001") {
+    return {
+      quote_id: "test-quote",
+      request_hash: "rh_test",
+      amount,
+      asset: "USDC",
+      chain: "solana",
+      merchant_address: merchantAddress,
+      expires_at: new Date(Date.now() + 300000).toISOString(),
+    };
+  }
+
+  function baseMockTx(
+    overrides: {
+      instructions?: unknown[];
+      preTokenBalances?: unknown[];
+      postTokenBalances?: unknown[];
+      err?: unknown;
+    } = {},
+  ) {
+    return {
+      meta: {
+        err: overrides.err ?? null,
+        preTokenBalances: overrides.preTokenBalances ?? [],
+        postTokenBalances: overrides.postTokenBalances ?? [],
+      },
+      transaction: {
+        message: {
+          accountKeys: [
+            { pubkey: { toBase58: () => payerAddress } },
+            { pubkey: { toBase58: () => "TokenAccount1111111111111111111111111111" } },
+            { pubkey: { toBase58: () => "TokenAccount2222222222222222222222222222" } },
+          ],
+          instructions: overrides.instructions ?? [],
+        },
+      },
+    };
+  }
+
+  it("should throw PaymentVerificationFailedError when Solana RPC fails", async () => {
+    const { Connection } = await import("@solana/web3.js");
+    const mockConn = buildMockConnection(null);
+    mockConn.getParsedTransaction.mockRejectedValue(new Error("Network error"));
+    vi.mocked(Connection).mockImplementation(() => mockConn as unknown as import("@solana/web3.js").Connection);
+
+    const service = createSolanaVerifyService({ rpcUrl: mockRpcUrl });
+    const proof = { tx_hash: txSignature, chain: "solana", payer_address: payerAddress };
+
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      PaymentVerificationFailedError,
+    );
+  });
+
+  it("should throw PaymentVerificationFailedError for invalid signature format", async () => {
+    const { Connection } = await import("@solana/web3.js");
+    const mockConn = buildMockConnection(null);
+    vi.mocked(Connection).mockImplementation(() => mockConn as unknown as import("@solana/web3.js").Connection);
+
+    const service = createSolanaVerifyService({ rpcUrl: mockRpcUrl });
+    const proof = { tx_hash: "short", chain: "solana", payer_address: payerAddress };
+
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      PaymentVerificationFailedError,
+    );
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      "Invalid Solana transaction signature",
+    );
+  });
+
+  it("should throw PaymentVerificationFailedError when transaction not found", async () => {
+    const { Connection } = await import("@solana/web3.js");
+    const mockConn = buildMockConnection(null);
+    vi.mocked(Connection).mockImplementation(() => mockConn as unknown as import("@solana/web3.js").Connection);
+
+    const service = createSolanaVerifyService({ rpcUrl: mockRpcUrl });
+    const proof = { tx_hash: txSignature, chain: "solana", payer_address: payerAddress };
+
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      PaymentVerificationFailedError,
+    );
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      "Solana transaction not found or not yet confirmed",
+    );
+  });
+
+  it("should throw PaymentVerificationFailedError when transaction failed on-chain", async () => {
+    const { Connection } = await import("@solana/web3.js");
+    const mockConn = buildMockConnection(
+      baseMockTx({ err: { InstructionError: [0, "Custom"] } }),
+    );
+    vi.mocked(Connection).mockImplementation(() => mockConn as unknown as import("@solana/web3.js").Connection);
+
+    const service = createSolanaVerifyService({ rpcUrl: mockRpcUrl });
+    const proof = { tx_hash: txSignature, chain: "solana", payer_address: payerAddress };
+
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      PaymentVerificationFailedError,
+    );
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      "Solana transaction failed",
+    );
+  });
+
+  it("should throw PaymentVerificationFailedError when payer does not match fee payer", async () => {
+    const { Connection } = await import("@solana/web3.js");
+    const wrongPayer = "WrongPayer1111111111111111111111111111111111";
+    const mockConn = buildMockConnection({
+      meta: { err: null },
+      transaction: {
+        message: {
+          accountKeys: [{ pubkey: { toBase58: () => wrongPayer } }],
+        },
+      },
+    });
+    vi.mocked(Connection).mockImplementation(() => mockConn as unknown as import("@solana/web3.js").Connection);
+
+    const service = createSolanaVerifyService({ rpcUrl: mockRpcUrl });
+    const proof = { tx_hash: txSignature, chain: "solana", payer_address: payerAddress };
+
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      PaymentVerificationFailedError,
+    );
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      "Payer address does not match transaction fee payer",
+    );
+  });
+
+  it("should throw PaymentVerificationFailedError when no SPL Token transfer instruction found", async () => {
+    const { Connection } = await import("@solana/web3.js");
+    const mockConn = buildMockConnection(baseMockTx());
+    vi.mocked(Connection).mockImplementation(() => mockConn as unknown as import("@solana/web3.js").Connection);
+
+    const service = createSolanaVerifyService({ rpcUrl: mockRpcUrl });
+    const proof = { tx_hash: txSignature, chain: "solana", payer_address: payerAddress };
+
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      PaymentVerificationFailedError,
+    );
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      "No USDC transfer from payer to merchant found in transaction",
+    );
+  });
+
+  it("should throw InsufficientPaymentError when USDC amount is too low", async () => {
+    const { Connection } = await import("@solana/web3.js");
+    const mockConn = buildMockConnection(
+      baseMockTx({
+        instructions: [
+          {
+            programId: SPL_TOKEN_PROGRAM_ID,
+            parsed: {
+              type: "transferChecked",
+              info: {
+                source: "TokenAccount1111111111111111111111111111",
+                destination: "TokenAccount2222222222222222222222222222",
+                mint: SOLANA_USDC_MINT,
+                tokenAmount: { amount: "100" }, // 0.0001 USDC
+              },
+            },
+          },
+        ],
+        preTokenBalances: [
+          { accountIndex: 1, mint: SOLANA_USDC_MINT, owner: payerAddress, uiTokenAmount: { amount: "1000000" } },
+          { accountIndex: 2, mint: SOLANA_USDC_MINT, owner: merchantAddress, uiTokenAmount: { amount: "0" } },
+        ],
+        postTokenBalances: [
+          { accountIndex: 1, mint: SOLANA_USDC_MINT, owner: payerAddress, uiTokenAmount: { amount: "999900" } },
+          { accountIndex: 2, mint: SOLANA_USDC_MINT, owner: merchantAddress, uiTokenAmount: { amount: "100" } },
+        ],
+      }),
+    );
+    vi.mocked(Connection).mockImplementation(() => mockConn as unknown as import("@solana/web3.js").Connection);
+
+    const service = createSolanaVerifyService({ rpcUrl: mockRpcUrl });
+    const proof = { tx_hash: txSignature, chain: "solana", payer_address: payerAddress };
+
+    await expect(service.verifyPayment(proof, buildChallenge("0.001"))).rejects.toThrow(
+      InsufficientPaymentError,
+    );
+  });
+
+  it("should throw PaymentVerificationFailedError when transfer is from wrong payer", async () => {
+    const { Connection } = await import("@solana/web3.js");
+    const otherPayer = "OtherPayer11111111111111111111111111111111";
+    const mockConn = buildMockConnection(
+      baseMockTx({
+        instructions: [
+          {
+            programId: SPL_TOKEN_PROGRAM_ID,
+            parsed: {
+              type: "transferChecked",
+              info: {
+                source: "TokenAccount1111111111111111111111111111",
+                destination: "TokenAccount2222222222222222222222222222",
+                mint: SOLANA_USDC_MINT,
+                tokenAmount: { amount: "1000000" },
+              },
+            },
+          },
+        ],
+        preTokenBalances: [
+          { accountIndex: 1, mint: SOLANA_USDC_MINT, owner: otherPayer, uiTokenAmount: { amount: "1000000" } },
+          { accountIndex: 2, mint: SOLANA_USDC_MINT, owner: merchantAddress, uiTokenAmount: { amount: "0" } },
+        ],
+        postTokenBalances: [
+          { accountIndex: 1, mint: SOLANA_USDC_MINT, owner: otherPayer, uiTokenAmount: { amount: "0" } },
+          { accountIndex: 2, mint: SOLANA_USDC_MINT, owner: merchantAddress, uiTokenAmount: { amount: "1000000" } },
+        ],
+      }),
+    );
+    vi.mocked(Connection).mockImplementation(() => mockConn as unknown as import("@solana/web3.js").Connection);
+
+    const service = createSolanaVerifyService({ rpcUrl: mockRpcUrl });
+    const proof = { tx_hash: txSignature, chain: "solana", payer_address: payerAddress };
+
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      PaymentVerificationFailedError,
+    );
+    await expect(service.verifyPayment(proof, buildChallenge())).rejects.toThrow(
+      "No USDC transfer from payer to merchant found in transaction",
+    );
+  });
+
+  it("should return verified result for valid Solana USDC payment", async () => {
+    const { Connection } = await import("@solana/web3.js");
+    const mockConn = buildMockConnection(
+      baseMockTx({
+        instructions: [
+          {
+            programId: SPL_TOKEN_PROGRAM_ID,
+            parsed: {
+              type: "transferChecked",
+              info: {
+                source: "TokenAccount1111111111111111111111111111",
+                destination: "TokenAccount2222222222222222222222222222",
+                mint: SOLANA_USDC_MINT,
+                tokenAmount: { amount: "1000000" },
+              },
+            },
+          },
+        ],
+        preTokenBalances: [
+          { accountIndex: 1, mint: SOLANA_USDC_MINT, owner: payerAddress, uiTokenAmount: { amount: "10000000" } },
+          { accountIndex: 2, mint: SOLANA_USDC_MINT, owner: merchantAddress, uiTokenAmount: { amount: "0" } },
+        ],
+        postTokenBalances: [
+          { accountIndex: 1, mint: SOLANA_USDC_MINT, owner: payerAddress, uiTokenAmount: { amount: "9000000" } },
+          { accountIndex: 2, mint: SOLANA_USDC_MINT, owner: merchantAddress, uiTokenAmount: { amount: "1000000" } },
+        ],
+      }),
+    );
+    vi.mocked(Connection).mockImplementation(() => mockConn as unknown as import("@solana/web3.js").Connection);
+
+    const service = createSolanaVerifyService({ rpcUrl: mockRpcUrl });
+    const proof = { tx_hash: txSignature, chain: "solana", payer_address: payerAddress };
+
+    const result = await service.verifyPayment(proof, buildChallenge("1.0"));
+    expect(result.verified).toBe(true);
+    expect(result.payer_address).toBe(payerAddress);
+    expect(result.amount).toBe("1.0");
+  });
+});

--- a/test/x402/verify.test.ts
+++ b/test/x402/verify.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   createPaymentVerifyService,
-} from "../../src/x402/verify.service.js";
+} from "../../src/x402/verify/index.js";
 import { createChainRegistry } from "../../src/x402/chain-registry.service.js";
 import { PaymentVerificationFailedError } from "../../src/errors.js";
 
@@ -13,7 +13,7 @@ describe("PaymentVerifyService", () => {
     rpcUrl: "https://mainnet.base.org",
   });
 
-  const service = createPaymentVerifyService(registry);
+  const service = createPaymentVerifyService({ chainRegistry: registry });
 
   it("should throw PaymentVerificationFailedError for unsupported chain", async () => {
     const proof = {


### PR DESCRIPTION
## 关联Issue
Closes #52

## 变更范围
- [x] 新建 `src/x402/verify/evm-verify.service.ts` — 提取现有 EVM 验证逻辑
- [x] 新建 `src/x402/verify/solana-verify.service.ts` — Solana SPL Token 转账验证（instruction 解析）
- [x] 新建 `src/x402/verify/index.ts` — 路由工厂：按 `chain === "solana"` 分发到 EVM 或 Solana 验证器
- [x] 删除 `src/x402/verify.service.ts` — 逻辑迁移到 `verify/` 目录
- [x] 修改 `src/x402/index.ts` — 更新导出路径
- [x] 修改 `src/config.ts` — 新增 `SOLANA_RPC_URL` 配置项
- [x] 修改 `src/app.ts` — 适配新的 `createPaymentVerifyService` 工厂签名
- [x] 修改 `package.json` — 添加 `@solana/web3.js`、`@solana/spl-token`
- [x] 新建 `test/x402/solana-verify.test.ts` — Solana 验证单元测试（instruction-based）
- [x] 修改 `test/helpers.ts` 和 `test/x402/verify.test.ts` — 更新导入路径

## 实现概要

### Solana 验证架构
与 EVM 验证并行，Solana 模块实现相同的 `IPaymentVerifyService` 接口：

1. **RPC 查询**：通过 `Connection.getParsedTransaction()` 获取解析后的交易详情
2. **Instruction 解析**（非余额推断）：直接遍历交易 instructions，查找 `spl-token` / `spl-token-2022` 的 `transfer` / `transferChecked` 指令
3. **Owner 校验**：通过 `meta.preTokenBalances` / `postTokenBalances` 中的 `accountIndex` 映射，确认 source ATA 的 owner 是 payer，destination ATA 的 owner 是 merchant
4. **Mint 校验**：`transferChecked` 直接校验 `mint === USDC_MINT`
5. **金额校验**：累加匹配到的 transfer 金额，与 challenge.amount 比较

### 路由逻辑
```typescript
// verify/index.ts
if (chain === "solana") {
  if (!solanaVerifier) throw PaymentVerificationFailedError("Solana verification is not configured");
  return solanaVerifier.verifyPayment(proof, challenge);
}
// 其他所有链走 EVM 验证器
return evmVerifier.verifyPayment(proof, challenge);
```

## 边界条件遵守
- [x] 未修改 `/tmp/` 目录文件
- [x] 未修改已有接口签名（`IPaymentVerifyService` 不变，仅工厂参数扩展）
- [x] 未重构现有代码（EVM 逻辑原样提取）
- [x] 账本写入逻辑不变（append-only）
- [x] 重放保护、challenge 签名、request_hash 绑定均未修改

## 测试证据
- [x] 单元测试：`pnpm test` 全部通过（198 tests passed）
- [x] Solana 测试覆盖场景：
  - RPC 连接失败
  - 无效签名格式
  - 交易未找到 / 链上失败
  - payer 与 fee payer 不匹配
  - 无 SPL Token transfer instruction
  - 支付金额不足（InsufficientPaymentError）
  - 非 payer 发起的 transfer（来源错误）
  - 有效支付验证通过
- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过

## 风险说明
- Solana 依赖包体积较大（`@solana/web3.js` ~2MB），对冷启动有轻微影响
- 生产环境需配置可靠的 Solana RPC 节点（如 Helius / QuickNode）

## 回滚方案
- 删除 `src/x402/verify/` 目录
- 恢复旧的 `src/x402/verify.service.ts`（已从 git 历史中保留）
- 回滚 `package.json` 中的依赖添加