### PR TITLE
fix(x402): correct ERC20_TRANSFER_SIGNATURE keccak256 hash (issue #60)

### DIFF
--- a/src/x402/verify/evm-verify.service.ts
+++ b/src/x402/verify/evm-verify.service.ts
@@ -40,7 +40,7 @@ export function getAssetDecimals(asset: string): number {
  * keccak256("Transfer(address,address,uint256)")
  */
 const ERC20_TRANSFER_SIGNATURE =
-  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df35b9d8";
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
 export interface IEvmVerifyService {
   verifyPayment(


### PR DESCRIPTION
## 关联 Issue
Closes #60

## 变更范围
- [x] `src/x402/verify/evm-verify.service.ts` — 修正 `ERC20_TRANSFER_SIGNATURE` 常量

## 修复

```diff
-  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df35b9d8";
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
```

viem keccak256 实测确认正确哈希值。

## 边界条件
- [x] 1 文件 1 行改动
- [x] 无接口变更
- [x] `pnpm typecheck` ✅
- [x] `pnpm test` 206 passed ✅

## 影响

修复前 EVM USDC 支付无法匹配 Transfer 事件（签名哈希错误）→ 本次修复 + #57 后 USDC 验证链路完整。