### PR TITLE
fix: remove provider prefix from model registration IDs (fixes #63 item 4)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -183,7 +183,7 @@ export async function buildApp(config: Config) {
   if (config.openaiApiKey) {
     const openaiBaseUrl = config.openaiBaseUrl || "https://api.openai.com/v1";
     providerRegistry.register(
-      "openai/gpt-4o",
+      "gpt-4o",
       new OpenAIAdapter(config.openaiApiKey, openaiBaseUrl),
       {
         input_usd_per_token: "0.0000025",
@@ -197,7 +197,7 @@ export async function buildApp(config: Config) {
   if (config.minimaxApiKey) {
     const minimaxBaseUrl = config.minimaxBaseUrl || "https://api.minimaxi.com/v1";
     providerRegistry.register(
-      "minimax/MiniMax-M2.5",
+      "MiniMax-M2.5",
       new OpenAIAdapter(config.minimaxApiKey, minimaxBaseUrl),
       {
         input_usd_per_token: "0.0000005",
@@ -211,7 +211,7 @@ export async function buildApp(config: Config) {
   if (config.minimaxApiKey) {
     const minimaxBaseUrl = config.minimaxBaseUrl || "https://api.minimaxi.com/v1";
     providerRegistry.register(
-      "minimax/MiniMax-M2.7",
+      "MiniMax-M2.7",
       new OpenAIAdapter(config.minimaxApiKey, minimaxBaseUrl),
       {
         input_usd_per_token: "0.000001",
@@ -226,7 +226,7 @@ export async function buildApp(config: Config) {
   if (config.moonshotApiKey) {
     const moonshotBaseUrl = config.moonshotBaseUrl || "https://api.moonshot.cn/v1";
     providerRegistry.register(
-      "moonshot/kimi-k2.6",
+      "kimi-k2.6",
       new OpenAIAdapter(config.moonshotApiKey, moonshotBaseUrl),
       {
         input_usd_per_token: "0.0000005",
@@ -241,7 +241,7 @@ export async function buildApp(config: Config) {
   if (config.zhipuApiKey) {
     const zhipuBaseUrl = config.zhipuBaseUrl || "https://open.bigmodel.cn/api/paas/v4";
     providerRegistry.register(
-      "zhipu/glm-5.1",
+      "glm-5.1",
       new OpenAIAdapter(config.zhipuApiKey, zhipuBaseUrl),
       {
         input_usd_per_token: "0.0000005",
@@ -256,7 +256,7 @@ export async function buildApp(config: Config) {
   if (config.deepseekApiKey) {
     const deepseekBaseUrl = config.deepseekBaseUrl || "https://api.deepseek.com/v1";
     providerRegistry.register(
-      "deepseek/deepseek-v4-pro",
+      "deepseek-v4-pro",
       new OpenAIAdapter(config.deepseekApiKey, deepseekBaseUrl),
       {
         input_usd_per_token: "0.00000014",
@@ -271,7 +271,7 @@ export async function buildApp(config: Config) {
   if (config.deepseekApiKey) {
     const deepseekBaseUrl = config.deepseekBaseUrl || "https://api.deepseek.com/v1";
     providerRegistry.register(
-      "deepseek/deepseek-v4-flash",
+      "deepseek-v4-flash",
       new OpenAIAdapter(config.deepseekApiKey, deepseekBaseUrl),
       {
         input_usd_per_token: "0.00000014",


### PR DESCRIPTION
## Summary

Remove `provider/` prefix from all model registration IDs in `src/app.ts`.

## Problem

Model IDs like `minimax/MiniMax-M2.7` were being passed directly to upstream APIs via `OpenAIAdapter.execute()`. The upstream providers (MiniMax, DeepSeek, Moonshot, Zhipu, etc.) expect bare model names without the provider prefix, causing API rejections.

## Fix

Changed all 7 model registration keys from prefixed to bare:

| Before | After |
|---|---|
| `openai/gpt-4o` | `gpt-4o` |
| `minimax/MiniMax-M2.5` | `MiniMax-M2.5` |
| `minimax/MiniMax-M2.7` | `MiniMax-M2.7` |
| `moonshot/kimi-k2.6` | `kimi-k2.6` |
| `zhipu/glm-5.1` | `glm-5.1` |
| `deepseek/deepseek-v4-pro` | `deepseek-v4-pro` |
| `deepseek/deepseek-v4-flash` | `deepseek-v4-flash` |

The adapter's `apiKey` and `baseUrl` already correctly identify the upstream provider — the prefix was only needed for internal namespacing and should not leak to upstream calls.

## Files Changed

- `src/app.ts` (+7/-7 lines, string changes only)

## Verification

- All 206 tests pass
- `GET /v1/models` returns bare model names
- Client calls with `{ model: "MiniMax-M2.7" }` now correctly pass `MiniMax-M2.7` to the upstream API

Closes #63 item 4