### PR TITLE
feat(x402): TokenRegistry + ChainConfig.tokens 解耦 (PR1)

### DIFF
--- a/src/x402/chain-config.ts
+++ b/src/x402/chain-config.ts
@@ -10,35 +10,65 @@ import {
 } from "viem/chains";
 import type { Chain, Address } from "viem";
 
+export interface TokenConfig {
+  symbol: string;
+  decimals: number;
+  address: Address;
+  type: "erc20" | "native";
+}
+
 export interface ChainConfig {
   chain: Chain;
   usdcAddress: Address;
+  tokens: Record<string, TokenConfig>;
+}
+
+function token(symbol: string, decimals: number, address: Address, type: "erc20" | "native"): TokenConfig {
+  return { symbol, decimals, address, type };
 }
 
 export const MAINNET_CHAINS: Record<string, ChainConfig> = {
   ethereum: {
     chain: mainnet,
     usdcAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    tokens: {
+      USDC: token("USDC", 6, "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", "erc20"),
+    },
   },
   base: {
     chain: base,
     usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    tokens: {
+      USDC: token("USDC", 6, "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", "erc20"),
+    },
   },
   arbitrum: {
     chain: arbitrum,
     usdcAddress: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    tokens: {
+      USDC: token("USDC", 6, "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", "erc20"),
+    },
   },
   optimism: {
     chain: optimism,
     usdcAddress: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+    tokens: {
+      USDC: token("USDC", 6, "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85", "erc20"),
+    },
   },
   polygon: {
     chain: polygon,
     usdcAddress: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+    tokens: {
+      USDC: token("USDC", 6, "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", "erc20"),
+    },
   },
   avalanche: {
     chain: avalanche,
     usdcAddress: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+    tokens: {
+      USDC: token("USDC", 6, "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E", "erc20"),
+    },
   },
 };
 
@@ -46,10 +76,16 @@ export const TESTNET_CHAINS: Record<string, ChainConfig> = {
   "ethereum-sepolia": {
     chain: sepolia,
     usdcAddress: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+    tokens: {
+      USDC: token("USDC", 6, "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", "erc20"),
+    },
   },
   "base-sepolia": {
     chain: baseSepolia,
     usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    tokens: {
+      USDC: token("USDC", 6, "0x036CbD53842c5426634e7929541eC2318f3dCF7e", "erc20"),
+    },
   },
 };
 

--- a/src/x402/token-registry.service.ts
+++ b/src/x402/token-registry.service.ts
@@ -1,0 +1,62 @@
+import type { TokenConfig } from "./chain-config.js";
+
+export interface ITokenRegistry {
+  register(chain: string, asset: string, config: TokenConfig): void;
+  get(chain: string, asset: string): TokenConfig | undefined;
+  isNativeAsset(chain: string, asset: string): boolean;
+  listAssets(chain: string): string[];
+}
+
+export function createTokenRegistry(): ITokenRegistry {
+  const store = new Map<string, Map<string, TokenConfig>>();
+
+  function chainKey(chain: string): string {
+    return chain.toLowerCase();
+  }
+
+  function assetKey(asset: string): string {
+    return asset.toUpperCase();
+  }
+
+  return {
+    register(chain: string, asset: string, config: TokenConfig): void {
+      const cKey = chainKey(chain);
+      let assets = store.get(cKey);
+      if (!assets) {
+        assets = new Map<string, TokenConfig>();
+        store.set(cKey, assets);
+      }
+      assets.set(assetKey(asset), config);
+    },
+
+    get(chain: string, asset: string): TokenConfig | undefined {
+      const assets = store.get(chainKey(chain));
+      if (!assets) return undefined;
+      return assets.get(assetKey(asset));
+    },
+
+    isNativeAsset(chain: string, asset: string): boolean {
+      const config = this.get(chain, asset);
+      return config?.type === "native";
+    },
+
+    listAssets(chain: string): string[] {
+      const assets = store.get(chainKey(chain));
+      if (!assets) return [];
+      return Array.from(assets.keys());
+    },
+  };
+}
+
+/** Convenience helper: pre-populate a registry from static ChainConfig records. */
+export function buildTokenRegistryFromChains(
+  chains: Record<string, { tokens: Record<string, TokenConfig> }>,
+): ITokenRegistry {
+  const registry = createTokenRegistry();
+  for (const [chainName, chainConfig] of Object.entries(chains)) {
+    for (const [symbol, config] of Object.entries(chainConfig.tokens)) {
+      registry.register(chainName, symbol, config);
+    }
+  }
+  return registry;
+}

--- a/test/x402/token-registry.test.ts
+++ b/test/x402/token-registry.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  createTokenRegistry,
+  buildTokenRegistryFromChains,
+} from "../../src/x402/token-registry.service.js";
+import type { TokenConfig } from "../../src/x402/chain-config.js";
+
+const usdcConfig: TokenConfig = {
+  symbol: "USDC",
+  decimals: 6,
+  address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  type: "erc20",
+};
+
+const ethConfig: TokenConfig = {
+  symbol: "ETH",
+  decimals: 18,
+  address: "0x0000000000000000000000000000000000000000",
+  type: "native",
+};
+
+describe("TokenRegistry", () => {
+  describe("register & get", () => {
+    it("should register and retrieve a token config", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+
+      const config = registry.get("ethereum", "USDC");
+      expect(config).toEqual(usdcConfig);
+    });
+
+    it("should be case-insensitive for chain names", () => {
+      const registry = createTokenRegistry();
+      registry.register("Ethereum", "USDC", usdcConfig);
+
+      expect(registry.get("ethereum", "USDC")).toEqual(usdcConfig);
+      expect(registry.get("ETHEREUM", "USDC")).toEqual(usdcConfig);
+    });
+
+    it("should be case-insensitive for asset symbols", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "usdc", usdcConfig);
+
+      expect(registry.get("ethereum", "USDC")).toEqual(usdcConfig);
+      expect(registry.get("ethereum", "Usdc")).toEqual(usdcConfig);
+    });
+
+    it("should return undefined for unregistered chain", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+
+      expect(registry.get("base", "USDC")).toBeUndefined();
+    });
+
+    it("should return undefined for unregistered asset on existing chain", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+
+      expect(registry.get("ethereum", "USDT")).toBeUndefined();
+    });
+  });
+
+  describe("isNativeAsset", () => {
+    it("should return true for native tokens", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "ETH", ethConfig);
+
+      expect(registry.isNativeAsset("ethereum", "ETH")).toBe(true);
+      expect(registry.isNativeAsset("ethereum", "eth")).toBe(true);
+    });
+
+    it("should return false for erc20 tokens", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+
+      expect(registry.isNativeAsset("ethereum", "USDC")).toBe(false);
+    });
+
+    it("should return false for unknown asset", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+
+      expect(registry.isNativeAsset("ethereum", "UNKNOWN")).toBe(false);
+    });
+
+    it("should return false for unknown chain", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+
+      expect(registry.isNativeAsset("solana", "USDC")).toBe(false);
+    });
+  });
+
+  describe("listAssets", () => {
+    it("should list all registered assets for a chain", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+      registry.register("ethereum", "ETH", ethConfig);
+
+      const assets = registry.listAssets("ethereum");
+      expect(assets).toHaveLength(2);
+      expect(assets).toContain("USDC");
+      expect(assets).toContain("ETH");
+    });
+
+    it("should return empty array for unknown chain", () => {
+      const registry = createTokenRegistry();
+      expect(registry.listAssets("solana")).toEqual([]);
+    });
+
+    it("should not leak assets across chains", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+      registry.register("base", "ETH", ethConfig);
+
+      expect(registry.listAssets("ethereum")).toEqual(["USDC"]);
+      expect(registry.listAssets("base")).toEqual(["ETH"]);
+    });
+  });
+
+  describe("buildTokenRegistryFromChains", () => {
+    it("should populate registry from chain config records", () => {
+      const chains = {
+        ethereum: {
+          tokens: {
+            USDC: usdcConfig,
+            ETH: ethConfig,
+          },
+        },
+        base: {
+          tokens: {
+            USDC: {
+              ...usdcConfig,
+              address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            },
+          },
+        },
+      };
+
+      const registry = buildTokenRegistryFromChains(chains);
+
+      expect(registry.get("ethereum", "USDC")).toEqual(usdcConfig);
+      expect(registry.get("ethereum", "ETH")).toEqual(ethConfig);
+      expect(registry.get("base", "USDC")?.address).toBe(
+        "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      );
+    });
+
+    it("should produce empty registry for empty chains", () => {
+      const registry = buildTokenRegistryFromChains({});
+      expect(registry.listAssets("ethereum")).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## 关联Issue
Closes #58

## 变更范围
- [x] `src/x402/chain-config.ts`: 新增 `TokenConfig` 接口，为 `ChainConfig` 添加 `tokens` 字典，USDC 作为首个 token 放入，保留 `usdcAddress` 确保向后兼容
- [x] `src/x402/token-registry.service.ts`: 新建 TokenRegistry 服务，支持注册、查询、isNativeAsset、listAssets，大小写不敏感
- [x] `test/x402/token-registry.test.ts`: 14 个单元测试覆盖核心场景

## 实现概要
PR1 聚焦纯数据层 + 注册中心：
1. `ChainConfig.tokens` 采用 `Record<string, TokenConfig>` 结构，每个链配置中 USDC 作为一等公民放入字典，与后续扩展的 USDT/DAI 等数据结构完全一致
2. `TokenRegistry` 参考 `ChainRegistry` 的依赖反转模式，提供运行时查询能力，消除 `isNativeAsset` 等硬编码
3. `usdcAddress` 暂时保留，供 `app.ts`、`evm-verify.service.ts` 等尚未迁移的旧代码使用，PR2/PR3 将逐步替换并移除

## 边界条件遵守
- [x] 未修改 `/tmp/` 目录文件
- [x] 未修改已有接口签名（`usdcAddress` 保留，现有代码零破坏）
- [x] 未重构现有代码
- [x] 改动 ≤3 个文件（2 源文件 + 1 测试文件）
- [x] 源文件改动 ≤200 行（约 96 行）

## 测试证据
- [x] 单元测试: 14 项全部通过
- [x] 集成测试: `pnpm test` 220 项全部通过
- [x] Lint: `pnpm lint` 通过
- [x] Typecheck: `pnpm typecheck` 通过

## 风险说明
- `usdcAddress` 为兼容字段，PR2/PR3 迁移完成后可安全删除
- 无运行时行为变更，纯新增数据层

## 回滚方案
```bash
git revert 6729dac
```