### PR TITLE
feat(x402): client-driven asset selection in challenge generation (PR3) (#58)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -307,8 +307,6 @@ export async function buildApp(config: Config) {
       challengeSecret: config.challengeSecret,
       challengeTtlSeconds: config.challengeTtlSeconds,
       merchantAddress: config.merchantAddress,
-      paymentChain: config.paymentChain,
-      paymentAsset: config.paymentAsset,
     }),
     verifyService: createPaymentVerifyService({
       chainRegistry,

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,8 +18,8 @@ const configSchema = z.object({
 
   merchantAddress: z.string().startsWith("0x"),
   paymentNetwork: z.enum(["mainnet", "testnet"]).default("mainnet"),
-  paymentChain: z.string().default("base"),
-  paymentAsset: z.string().default("USDC"),
+  paymentChain: z.string().optional(),
+  paymentAsset: z.string().optional(),
 
   openaiApiKey: z.string().optional(),
   openaiBaseUrl: z.string().url().optional(),

--- a/src/gateway/routes.ts
+++ b/src/gateway/routes.ts
@@ -47,12 +47,20 @@ export function registerRoutes(
     const idempotencyKey = request.headers["idempotency-key"] as
       | string
       | undefined;
+    const preferredAsset = (request.headers["x-402-preferred-asset"] as
+      | string
+      | undefined) ?? "USDC";
+    const preferredChain = (request.headers["x-402-preferred-chain"] as
+      | string
+      | undefined) ?? "base";
 
     // No payment headers -> return 402 with challenge
     if (!challengeHeader || !paymentHeader) {
       const requirements = await services.challengeService.generateChallenge(
         body,
         "0.001",
+        preferredAsset,
+        preferredChain,
       );
       return reply.status(402).send({
         error: { code: "payment_required", message: "Payment proof required" },

--- a/src/x402/challenge.service.ts
+++ b/src/x402/challenge.service.ts
@@ -7,6 +7,8 @@ export interface IChallengeService {
   generateChallenge(
     request: ChatCompletionRequest,
     estimatedCost: string,
+    asset: string,
+    chain: string,
   ): Promise<PaymentRequirements>;
   verifyChallenge(
     challengeToken: string,
@@ -19,21 +21,19 @@ export function createChallengeService(deps: {
   challengeSecret: string;
   challengeTtlSeconds: number;
   merchantAddress: string;
-  paymentChain: string;
-  paymentAsset: string;
 }): IChallengeService {
   const {
     challengeSecret,
     challengeTtlSeconds,
     merchantAddress,
-    paymentChain,
-    paymentAsset,
   } = deps;
 
   return {
     generateChallenge: async function (
       request: ChatCompletionRequest,
       estimatedCost: string,
+      asset: string,
+      chain: string,
     ): Promise<PaymentRequirements> {
       const { nanoid } = await import("nanoid");
       const quoteId = nanoid();
@@ -43,8 +43,8 @@ export function createChallengeService(deps: {
         quote_id: quoteId,
         request_hash: requestHash,
         amount: estimatedCost,
-        asset: paymentAsset,
-        chain: paymentChain,
+        asset,
+        chain,
         merchant_address: merchantAddress,
         expires_at: new Date(
           Date.now() + challengeTtlSeconds * 1000,

--- a/test/integration/flow.test.ts
+++ b/test/integration/flow.test.ts
@@ -313,6 +313,8 @@ describe("End-to-End Integration Flow", () => {
             messages: [{ role: "user", content: "Hello" }],
           },
           "0.001",
+          "USDC",
+          "base",
         );
 
       // Manually tamper with the challenge to make it expired

--- a/test/x402/challenge-security.test.ts
+++ b/test/x402/challenge-security.test.ts
@@ -10,8 +10,6 @@ describe("ChallengeService Security", () => {
     challengeSecret: "test-secret-at-least-32-chars-long-for-testing",
     challengeTtlSeconds: 300,
     merchantAddress: "0x0000000000000000000000000000000000000001",
-    paymentChain: "base",
-    paymentAsset: "USDC",
   });
 
   it("should reject invalid challenge token due to wrong signature", async () => {
@@ -20,7 +18,7 @@ describe("ChallengeService Security", () => {
       messages: [{ role: "user" as const, content: "hello" }],
     };
 
-    const validChallenge = await service.generateChallenge(request, "0.001");
+    const validChallenge = await service.generateChallenge(request, "0.001", "USDC", "base");
     const tamperedToken = validChallenge.challenge_token.slice(0, -1) + "X";
 
     await expect(
@@ -51,11 +49,9 @@ describe("ChallengeService Security", () => {
       challengeSecret: "test-secret-at-least-32-chars-long-for-testing",
       challengeTtlSeconds: -1,
       merchantAddress: "0x0000000000000000000000000000000000000001",
-      paymentChain: "base",
-      paymentAsset: "USDC",
     });
 
-    const challenge = await shortLivedService.generateChallenge(request, "0.001");
+    const challenge = await shortLivedService.generateChallenge(request, "0.001", "USDC", "base");
 
     await expect(
       shortLivedService.verifyChallenge(challenge.challenge_token, request),
@@ -73,7 +69,7 @@ describe("ChallengeService Security", () => {
       messages: [{ role: "user" as const, content: "different content" }],
     };
 
-    const challenge = await service.generateChallenge(request1, "0.001");
+    const challenge = await service.generateChallenge(request1, "0.001", "USDC", "base");
 
     await expect(
       service.verifyChallenge(challenge.challenge_token, request2),
@@ -86,7 +82,7 @@ describe("ChallengeService Security", () => {
       messages: [{ role: "user" as const, content: "hello" }],
     };
 
-    const challenge = await service.generateChallenge(request, "0.001");
+    const challenge = await service.generateChallenge(request, "0.001", "USDC", "base");
 
     const result = await service.verifyChallenge(challenge.challenge_token, request);
 

--- a/test/x402/challenge.test.ts
+++ b/test/x402/challenge.test.ts
@@ -6,8 +6,6 @@ describe("ChallengeService", () => {
     challengeSecret: "test-secret-at-least-32-chars-long-for-testing",
     challengeTtlSeconds: 300,
     merchantAddress: "0x0000000000000000000000000000000000000001",
-    paymentChain: "base",
-    paymentAsset: "USDC",
   });
 
   it("should exist and have the expected interface", () => {
@@ -22,7 +20,7 @@ describe("ChallengeService", () => {
       model: "gpt-4",
       messages: [{ role: "user" as const, content: "hello" }],
     };
-    const result = await service.generateChallenge(request, "0.001");
+    const result = await service.generateChallenge(request, "0.001", "USDC", "base");
 
     expect(result).toHaveProperty("quote_id");
     expect(result).toHaveProperty("chain", "base");


### PR DESCRIPTION
## 关联 Issue
Closes #58

## 变更范围
- `src/x402/challenge.service.ts` — `generateChallenge` 方法签名改为接收 `asset` 和 `chain` 参数，从 deps 中彻底移除 `paymentAsset` / `paymentChain`
- `src/gateway/routes.ts` — 从请求头 `X-402-Preferred-Asset` / `X-402-Preferred-Chain` 读取客户端偏好，传给 `generateChallenge`
- `src/config.ts` — `paymentChain` / `paymentAsset` 从 `.default()` 改为 `.optional()`
- `src/app.ts` — 移除 `createChallengeService` 中的 `paymentChain` / `paymentAsset` 传入
- `test/x402/challenge.test.ts` / `challenge-security.test.ts` — 更新所有 `generateChallenge` 调用
- `test/integration/flow.test.ts` — 更新 `generateChallenge` 调用

## 实现概要
Issue #58 的第四个耦合点：`challenge.service.ts` 中 `asset` 服务端写死，客户端不能选。

**修复方案**：
- `generateChallenge(request, estimatedCost, asset, chain)` — asset/chain 由调用方传入
- Gateway handler 从 `X-402-Preferred-Asset` / `X-402-Preferred-Chain` header 读取客户端偏好
- 未提供 header 时回退到 `"USDC"` / `"base"` 默认值
- `createChallengeService` 的 deps 中彻底移除 `paymentChain` / `paymentAsset`

## 边界条件遵守
- [x] 未修改 `/tmp/` 目录文件
- [x] 修改了 `IChallengeService.generateChallenge` 签名（Issue 明确要求的重构）
- [x] typecheck 通过
- [x] lint 通过

## 测试证据
- [x] `pnpm test` 通过 (219/219)
- [x] 所有现有 challenge 相关测试无需功能变更，仅更新调用参数

## 风险说明
- `generateChallenge` 签名变化，所有调用方必须更新。搜索全仓库后已确认全部更新。
- 客户端未提供 header 时默认使用 USDC/base，行为与之前一致。

## 回滚方案
- `git revert` 即可恢复为服务端写死的旧版