### PR TITLE
fix(x402): Solana payment unavailable + cross-chain validation (#70)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -301,6 +301,14 @@ export async function buildApp(config: Config) {
   const chainRegistry = buildChainRegistry(config);
   const tokenRegistry = buildTokenRegistryFromChains(getSupportedChains(config.paymentNetwork));
 
+  // Register Solana assets (not covered by EVM chain config)
+  tokenRegistry.register("solana", "USDC", {
+    symbol: "USDC",
+    decimals: 6,
+    address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" as `0x${string}`,
+    type: "erc20",
+  });
+
   const services: ServiceContainer = {
     providerRegistry,
     challengeService: createChallengeService({

--- a/src/gateway/routes.ts
+++ b/src/gateway/routes.ts
@@ -74,6 +74,13 @@ export function registerRoutes(
       const challengePayload: ChallengePayload =
         await services.challengeService.verifyChallenge(challengeHeader, body);
 
+      // Cross-chain validation: ensure payment chain matches challenge chain
+      if (paymentProof.chain.toLowerCase() !== challengePayload.chain.toLowerCase()) {
+        throw new PaymentVerificationFailedError(
+          `Chain mismatch: challenge requires ${challengePayload.chain}, but proof is on ${paymentProof.chain}`
+        );
+      }
+
       // Idempotency check
       if (idempotencyKey) {
         const cached =

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -169,8 +169,6 @@ export function buildTestApp(overrides: Partial<ServiceContainer> = {}) {
       challengeSecret: "test-secret-at-least-32-chars-long-for-testing",
       challengeTtlSeconds: 300,
       merchantAddress: "0x0000000000000000000000000000000000000001",
-      paymentChain: "base",
-      paymentAsset: "USDC",
     }),
     verifyService: createPaymentVerifyService({
       chainRegistry: (() => {
@@ -252,8 +250,6 @@ export function buildMockedTestApp(options?: {
       challengeSecret: "test-secret-at-least-32-chars-long-for-testing",
       challengeTtlSeconds: 300,
       merchantAddress: "0x0000000000000000000000000000000000000001",
-      paymentChain: "base",
-      paymentAsset: "USDC",
     }),
     verifyService,
     replayService,

--- a/test/integration/flow.test.ts
+++ b/test/integration/flow.test.ts
@@ -390,6 +390,46 @@ describe("End-to-End Integration Flow", () => {
       const body = response.json();
       expect(body.error.code).toBe("request_hash_mismatch");
     });
+
+    it("should reject payment on wrong chain", async () => {
+      const { app } = buildMockedTestApp();
+
+      // Get challenge for base chain
+      const challengeResponse = await app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        payload: {
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+      });
+
+      expect(challengeResponse.statusCode).toBe(402);
+      const challengeToken =
+        challengeResponse.json().payment_requirements.challenge_token;
+
+      // Submit payment with wrong chain (ethereum instead of base)
+      const paymentProof = createMockPaymentProof({ chain: "ethereum" });
+      const paymentHeader = encodePaymentProof(paymentProof);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        payload: {
+          model: "openai/gpt-4o",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+        headers: {
+          "x-402-challenge": challengeToken,
+          "x-402-payment": paymentHeader,
+        },
+      });
+
+      expect(response.statusCode).toBe(402);
+      const body = response.json();
+      expect(body.error.code).toBe("payment_verification_failed");
+      expect(body.error.message).toContain("Chain mismatch");
+    });
   });
 
   describe("Routing Failures and Fallback", () => {

--- a/test/x402/token-registry.test.ts
+++ b/test/x402/token-registry.test.ts
@@ -120,7 +120,7 @@ describe("TokenRegistry", () => {
 
   describe("buildTokenRegistryFromChains", () => {
     it("should populate registry from chain config records", () => {
-      const chains = {
+      const chains: Record<string, { tokens: Record<string, TokenConfig> }> = {
         ethereum: {
           tokens: {
             USDC: usdcConfig,
@@ -149,6 +149,33 @@ describe("TokenRegistry", () => {
     it("should produce empty registry for empty chains", () => {
       const registry = buildTokenRegistryFromChains({});
       expect(registry.listAssets("ethereum")).toEqual([]);
+    });
+
+    it("should support Solana when registered after EVM chains", () => {
+      const registry = buildTokenRegistryFromChains({
+        base: {
+          tokens: {
+            USDC: {
+              symbol: "USDC",
+              decimals: 6,
+              address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+              type: "erc20",
+            },
+          },
+        },
+      });
+
+      registry.register("solana", "USDC", {
+        symbol: "USDC",
+        decimals: 6,
+        address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" as `0x${string}`,
+        type: "erc20",
+      });
+
+      expect(registry.get("solana", "USDC")).toBeDefined();
+      expect(registry.get("solana", "USDC")?.decimals).toBe(6);
+      expect(registry.get("solana", "USDC")?.symbol).toBe("USDC");
+      expect(registry.isNativeAsset("solana", "USDC")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## 关联 Issue
Closes #70

## 问题背景
Issue #58 的 PR 序列（#67/#68/#69）在解耦 token/asset 过程中引入了两个上线级缺陷。

## 修复内容

### 缺陷1：Solana 支付完全不可用（PR#68 回归）
**根因**：`tokenRegistry` 仅通过 `buildTokenRegistryFromChains(getSupportedChains())` 构建，而 `getSupportedChains()` 只返回 EVM 链，未包含 Solana。

**修复**：在 `app.ts` 中显式注册 Solana USDC：
```typescript
tokenRegistry.register("solana", "USDC", {
  symbol: "USDC",
  decimals: 6,
  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" as `0x${string}`,
  type: "erc20",
});
```

### 缺陷2：EVM 跨链验证缺失
**根因**：没有验证 `paymentProof.chain === challengePayload.chain`，攻击者可以在错误的链上支付（如 challenge 要求 base，但用户在 ethereum 付款）。

**修复**：在 `gateway/routes.ts` 中 `verifyChallenge` 之后添加链一致性校验：
```typescript
if (paymentProof.chain.toLowerCase() !== challengePayload.chain.toLowerCase()) {
  throw new PaymentVerificationFailedError(
    `Chain mismatch: challenge requires ${challengePayload.chain}, but proof is on ${paymentProof.chain}`
  );
}
```

## 边界条件遵守
- [x] 未修改 `/tmp/` 目录文件
- [x] 未修改已有接口签名
- [x] typecheck 通过
- [x] lint 通过

## 测试证据
- [x] `pnpm test` 通过 (219/219)

## 风险说明
- 低风险的补充修复，恢复 Solana 支付功能并添加安全校验。

## 回滚方案
- `git revert` 即可恢复