### PR TITLE
feat(billing): modular payment amount layer — decouple pricing estimation from challenge

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -87,6 +87,10 @@ import {
   type ILedgerService,
 } from "./billing/ledger.service.js";
 import {
+  createPaymentService,
+  type IPaymentService,
+} from "./billing/payment.service.js";
+import {
   createTraceService,
   type ITraceService,
 } from "./audit/trace.service.js";
@@ -106,6 +110,10 @@ export interface ServiceContainer {
   ledgerService: ILedgerService;
   traceService: ITraceService;
   receiptService: IReceiptService;
+  /** Modular payment estimation & validation layer (decoupled from x402 challenge). */
+  paymentService: IPaymentService;
+  /** Platform fee in basis points (e.g., 50 = 0.5%). From PLATFORM_FEE_BPS config. */
+  platformFeeBps: number;
   /** Default payment chain from PAYMENT_CHAIN env var. Falls back to "base" if unset. */
   paymentChain: string;
 }
@@ -293,6 +301,7 @@ export async function buildApp(config: Config) {
     );
   }
 
+  const costService = createCostService();
   const ledgerService = createLedgerService();
   const traceService = createTraceService();
 
@@ -367,7 +376,9 @@ export async function buildApp(config: Config) {
         });
       },
     }),
-    costService: createCostService(),
+    costService,
+    paymentService: createPaymentService({ costService }),
+    platformFeeBps: config.platformFeeBps,
     ledgerService,
     traceService,
     receiptService: createReceiptService({ traceService, ledgerService }),

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -5,3 +5,5 @@ export { createCostService } from './cost.service.js';
 export type { ICostService } from './cost.service.js';
 export { createLedgerService } from './ledger.service.js';
 export type { ILedgerService } from './ledger.service.js';
+export { createPaymentService } from './payment.service.js';
+export type { IPaymentService, EstimatedTokens } from './payment.service.js';

--- a/src/billing/payment.service.ts
+++ b/src/billing/payment.service.ts
@@ -1,0 +1,161 @@
+import type { ChatCompletionRequest, ModelPricing } from "../types.js";
+import { InsufficientPaymentError } from "../errors.js";
+import type { ICostService } from "./cost.service.js";
+
+// ---------------------------------------------------------------------------
+// Payment Amount Estimation & Validation Layer
+//
+// This service is the modular payment amount layer, decoupled from x402
+// challenge generation. Responsible for:
+//   1. Token estimation from chat completion requests (pre-execution)
+//   2. Estimated cost calculation (model pricing × estimated tokens + fee)
+//   3. Post-execution payment validation (actual ≤ authorized)
+//
+// Design follows x402 "upto" scheme principles:
+//   - Client authorizes a maximum amount (estimated via this service)
+//   - Actual usage may be less than or equal to the authorized amount
+//   - If actual exceeds authorized, the request is rejected
+//
+// This layer is protocol-agnostic and can be reused when #77 introduces
+// the official x402 upto scheme.
+// ---------------------------------------------------------------------------
+
+/** Default max completion tokens for cost estimation (when not specified). */
+const DEFAULT_MAX_COMPLETION_TOKENS = 4096;
+
+/** Approximate token-to-character ratio for English text. */
+const CHARS_PER_TOKEN = 4;
+
+/** Estimated token counts from a chat completion request. */
+export interface EstimatedTokens {
+  estimated_prompt_tokens: number;
+  estimated_completion_tokens: number;
+  estimated_total_tokens: number;
+}
+
+/**
+ * Interface for the payment estimation & validation service.
+ * Part of the modular payment amount layer (Issue #45).
+ */
+export interface IPaymentService {
+  /**
+   * Estimate token usage from a chat completion request body.
+   *
+   * Heuristic:
+   *   - Prompt tokens ≈ ceil(total_message_characters / 4)
+   *   - Completion tokens = DEFAULT_MAX_COMPLETION_TOKENS (4096)
+   *
+   * This provides a conservative upper bound for the "upto" scheme.
+   *
+   * @param request - The chat completion request with messages
+   * @returns Estimated token counts
+   */
+  estimateTokens(request: ChatCompletionRequest): EstimatedTokens;
+
+  /**
+   * Calculate the total estimated cost based on token estimates and model pricing.
+   *
+   * Uses nano-dollar precision via the injected cost service.
+   * Formula: (prompt_tokens × input_price) + (completion_tokens × output_price)
+   *          + platform_fee
+   *
+   * @param estimatedTokens - Token estimates from estimateTokens()
+   * @param pricing - Model pricing (input/output USD per token)
+   * @param feeBps - Platform fee in basis points
+   * @returns Total estimated cost as decimal string (e.g., "0.0012")
+   */
+  estimateTotalCost(
+    estimatedTokens: EstimatedTokens,
+    pricing: ModelPricing,
+    feeBps: number,
+  ): string;
+
+  /**
+   * Validate that the actual execution cost does not exceed the authorized amount.
+   *
+   * Follows x402 "upto" semantics: actual usage must be ≤ authorized maximum.
+   * Throws InsufficientPaymentError with details if actual > authorized.
+   *
+   * @param actualTotalUsd - Actual total cost after LLM execution (decimal string)
+   * @param authorizedAmount - Amount authorized in the 402 challenge (decimal string)
+   * @throws InsufficientPaymentError if actual exceeds authorized
+   */
+  validatePayment(actualTotalUsd: string, authorizedAmount: string): void;
+}
+
+/** Dependencies for PaymentService factory. */
+export interface PaymentServiceDeps {
+  costService: ICostService;
+}
+
+/**
+ * Create a PaymentService instance.
+ *
+ * The payment service is protocol-agnostic — it knows nothing about x402
+ * challenge tokens or on-chain verification. It only handles the monetary
+ * estimation and validation layer.
+ *
+ * @param deps - Service dependencies
+ * @returns IPaymentService implementation
+ */
+export function createPaymentService(deps: PaymentServiceDeps): IPaymentService {
+  const { costService } = deps;
+
+  function estimateTokens(request: ChatCompletionRequest): EstimatedTokens {
+    const totalChars = request.messages.reduce(
+      (sum, msg) => sum + (msg.content?.length ?? 0),
+      0,
+    );
+    const estimatedPromptTokens = Math.ceil(totalChars / CHARS_PER_TOKEN);
+    const estimatedCompletionTokens = DEFAULT_MAX_COMPLETION_TOKENS;
+
+    return {
+      estimated_prompt_tokens: estimatedPromptTokens,
+      estimated_completion_tokens: estimatedCompletionTokens,
+      estimated_total_tokens:
+        estimatedPromptTokens + estimatedCompletionTokens,
+    };
+  }
+
+  function estimateTotalCost(
+    estimatedTokens: EstimatedTokens,
+    pricing: ModelPricing,
+    feeBps: number,
+  ): string {
+    // Build a synthetic usage record for cost calculation
+    const usage = {
+      request_id: "" as import("../types.js").RequestId,
+      model_id: "",
+      prompt_tokens: estimatedTokens.estimated_prompt_tokens,
+      completion_tokens: estimatedTokens.estimated_completion_tokens,
+      total_tokens: estimatedTokens.estimated_total_tokens,
+    };
+
+    const breakdown = costService.calculateCost(usage, pricing, feeBps);
+    return breakdown.total_usd;
+  }
+
+  function validatePayment(
+    actualTotalUsd: string,
+    authorizedAmount: string,
+  ): void {
+    const actual = parseFloat(actualTotalUsd);
+    const authorized = parseFloat(authorizedAmount);
+
+    if (Number.isNaN(actual) || Number.isNaN(authorized)) {
+      throw new Error(
+        `Invalid numeric values for payment validation: actual="${actualTotalUsd}", authorized="${authorizedAmount}"`,
+      );
+    }
+
+    if (actual > authorized) {
+      throw new InsufficientPaymentError(authorizedAmount, actualTotalUsd);
+    }
+  }
+
+  return {
+    estimateTokens,
+    estimateTotalCost,
+    validatePayment,
+  };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,7 @@ const configSchema = z.object({
   alchemyApiKey: z.string().optional(),
   solanaRpcUrl: z.string().url().optional(),
 
-  platformFeeBps: z.coerce.number().default(500),
+  platformFeeBps: z.coerce.number().default(50),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/src/gateway/routes.ts
+++ b/src/gateway/routes.ts
@@ -56,9 +56,18 @@ export function registerRoutes(
 
     // No payment headers -> return 402 with challenge
     if (!challengeHeader || !paymentHeader) {
+      // Estimate payment amount based on model pricing + token estimation
+      const pricing = services.providerRegistry.getModelPricing(body.model);
+      const estimatedTokens = services.paymentService.estimateTokens(body);
+      const estimatedCost = services.paymentService.estimateTotalCost(
+        estimatedTokens,
+        pricing,
+        services.platformFeeBps,
+      );
+
       const requirements = await services.challengeService.generateChallenge(
         body,
-        "0.001",
+        estimatedCost,
         preferredAsset,
         preferredChain,
       );
@@ -135,7 +144,17 @@ export function registerRoutes(
           completion_tokens: response.usage.completion_tokens,
           total_tokens: response.usage.total_tokens,
         };
-        const cost = services.costService.calculateCost(usage, pricing, 50);
+        const cost = services.costService.calculateCost(
+          usage,
+          pricing,
+          services.platformFeeBps,
+        );
+
+        // Validate: actual cost must not exceed authorized amount (x402 upto semantics)
+        services.paymentService.validatePayment(
+          cost.total_usd,
+          challengePayload.amount,
+        );
 
         // Commit to ledger
         await services.ledgerService.commit({

--- a/test/billing/payment.test.ts
+++ b/test/billing/payment.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import { createPaymentService } from "../../src/billing/payment.service.js";
+import { createCostService } from "../../src/billing/cost.service.js";
+import { InsufficientPaymentError } from "../../src/errors.js";
+import type { ChatCompletionRequest, ModelPricing } from "../../src/types.js";
+
+const TEST_PRICING: ModelPricing = {
+  input_usd_per_token: "0.00001",
+  output_usd_per_token: "0.00003",
+  effective_at: new Date().toISOString(),
+};
+
+const TEST_FEE_BPS = 50;
+
+function makeService() {
+  const costService = createCostService();
+  return createPaymentService({ costService });
+}
+
+function makeRequest(
+  content: string,
+  model = "openai/gpt-4o",
+): ChatCompletionRequest {
+  return {
+    model,
+    messages: [{ role: "user" as const, content }],
+  };
+}
+
+describe("PaymentService", () => {
+  describe("estimateTokens", () => {
+    it("should estimate prompt tokens from message content length", () => {
+      const service = makeService();
+      const request = makeRequest("Hello, how are you?");
+      const tokens = service.estimateTokens(request);
+
+      // "Hello, how are you?" = 19 chars → ceil(19/4) = 5
+      expect(tokens.estimated_prompt_tokens).toBeGreaterThan(0);
+      // 4096 default completion tokens
+      expect(tokens.estimated_completion_tokens).toBe(4096);
+      expect(tokens.estimated_total_tokens).toBe(
+        tokens.estimated_prompt_tokens + tokens.estimated_completion_tokens,
+      );
+    });
+
+    it("should estimate 1 prompt token for very short messages", () => {
+      const service = makeService();
+      const request = makeRequest("Hi");
+      const tokens = service.estimateTokens(request);
+
+      // "Hi" = 2 chars → ceil(2/4) = 1
+      expect(tokens.estimated_prompt_tokens).toBe(1);
+    });
+
+    it("should handle multi-message requests", () => {
+      const service = makeService();
+      const request: ChatCompletionRequest = {
+        model: "openai/gpt-4o",
+        messages: [
+          { role: "system", content: "You are a helpful assistant." },
+          { role: "user", content: "Tell me about the weather." },
+          { role: "assistant", content: "The weather today is sunny." },
+          { role: "user", content: "What about tomorrow?" },
+        ],
+      };
+      const tokens = service.estimateTokens(request);
+
+      // Sum of all content lengths / 4
+      expect(tokens.estimated_prompt_tokens).toBeGreaterThan(0);
+      expect(tokens.estimated_completion_tokens).toBe(4096);
+    });
+
+    it("should handle empty content messages", () => {
+      const service = makeService();
+      const request: ChatCompletionRequest = {
+        model: "openai/gpt-4o",
+        messages: [{ role: "user", content: "" }],
+      };
+      const tokens = service.estimateTokens(request);
+
+      expect(tokens.estimated_prompt_tokens).toBe(0);
+    });
+  });
+
+  describe("estimateTotalCost", () => {
+    it("should calculate estimated total cost based on model pricing", () => {
+      const service = makeService();
+      const tokens = {
+        estimated_prompt_tokens: 1000,
+        estimated_completion_tokens: 500,
+        estimated_total_tokens: 1500,
+      };
+      const total = service.estimateTotalCost(tokens, TEST_PRICING, TEST_FEE_BPS);
+
+      // prompt: 1000 * 0.00001 = 0.01
+      // completion: 500 * 0.00003 = 0.015
+      // subtotal = 0.025
+      // fee = 0.025 * 50 / 10000 = 0.000125
+      // total = 0.025125
+      expect(total).toBeDefined();
+      expect(parseFloat(total)).toBeGreaterThan(0);
+    });
+
+    it("should return total greater than subtotal due to fee", () => {
+      const service = makeService();
+      const tokens = {
+        estimated_prompt_tokens: 100,
+        estimated_completion_tokens: 100,
+        estimated_total_tokens: 200,
+      };
+
+      const total = service.estimateTotalCost(tokens, TEST_PRICING, TEST_FEE_BPS);
+      const totalWithFee = service.estimateTotalCost(
+        tokens,
+        TEST_PRICING,
+        500, // 5% fee
+      );
+
+      // Higher feeBps should produce higher total
+      expect(parseFloat(totalWithFee)).toBeGreaterThan(parseFloat(total));
+    });
+
+    it("should return deterministic results for same inputs", () => {
+      const service = makeService();
+      const tokens = {
+        estimated_prompt_tokens: 1000,
+        estimated_completion_tokens: 500,
+        estimated_total_tokens: 1500,
+      };
+
+      const result1 = service.estimateTotalCost(
+        tokens,
+        TEST_PRICING,
+        TEST_FEE_BPS,
+      );
+      const result2 = service.estimateTotalCost(
+        tokens,
+        TEST_PRICING,
+        TEST_FEE_BPS,
+      );
+
+      expect(result1).toBe(result2);
+    });
+  });
+
+  describe("validatePayment", () => {
+    it("should not throw when actual cost equals authorized amount", () => {
+      const service = makeService();
+      expect(() =>
+        service.validatePayment("0.001", "0.001"),
+      ).not.toThrow();
+    });
+
+    it("should not throw when actual cost is less than authorized amount", () => {
+      const service = makeService();
+      expect(() =>
+        service.validatePayment("0.0005", "0.001"),
+      ).not.toThrow();
+    });
+
+    it("should throw InsufficientPaymentError when actual exceeds authorized", () => {
+      const service = makeService();
+      expect(() =>
+        service.validatePayment("0.002", "0.001"),
+      ).toThrow(InsufficientPaymentError);
+    });
+
+    it("should include actual and required amounts in error message", () => {
+      const service = makeService();
+      try {
+        service.validatePayment("0.002", "0.001");
+      } catch (error) {
+        expect(error).toBeInstanceOf(InsufficientPaymentError);
+        expect((error as InsufficientPaymentError).message).toContain(
+          "0.002",
+        );
+        expect((error as InsufficientPaymentError).message).toContain(
+          "0.001",
+        );
+      }
+    });
+
+    it("should throw on invalid numeric inputs", () => {
+      const service = makeService();
+      expect(() =>
+        service.validatePayment("not-a-number", "0.001"),
+      ).toThrow("Invalid numeric values");
+      expect(() =>
+        service.validatePayment("0.001", "not-a-number"),
+      ).toThrow("Invalid numeric values");
+    });
+
+    it("should handle zero authorized amount", () => {
+      const service = makeService();
+      // Actual > 0 authorized → should throw
+      expect(() =>
+        service.validatePayment("0.001", "0"),
+      ).toThrow(InsufficientPaymentError);
+    });
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -20,6 +20,7 @@ import {
 import { createMeterService } from "../src/billing/meter.service.js";
 import { createCostService } from "../src/billing/cost.service.js";
 import { createLedgerService } from "../src/billing/ledger.service.js";
+import { createPaymentService } from "../src/billing/payment.service.js";
 import { createTraceService } from "../src/audit/trace.service.js";
 import { createReceiptService } from "../src/audit/receipt.service.js";
 import type { ServiceContainer } from "../src/app.js";
@@ -159,6 +160,7 @@ export function buildTestApp(overrides: Partial<ServiceContainer> = {}) {
     effective_at: new Date().toISOString(),
   });
 
+  const costService = createCostService();
   const ledgerService = createLedgerService();
   const traceService = createTraceService();
 
@@ -200,7 +202,9 @@ export function buildTestApp(overrides: Partial<ServiceContainer> = {}) {
     meterService: createMeterService({
       recordUsage: async () => {},
     }),
-    costService: createCostService(),
+    costService,
+    paymentService: createPaymentService({ costService }),
+    platformFeeBps: 50,
     ledgerService,
     traceService,
     receiptService: createReceiptService({ traceService, ledgerService }),
@@ -232,6 +236,7 @@ export function buildMockedTestApp(options?: {
     effective_at: new Date().toISOString(),
   });
 
+  const costService = createCostService();
   const ledgerService = createLedgerService();
   const traceService = createTraceService();
   const replayService = createMockReplayService();
@@ -260,7 +265,9 @@ export function buildMockedTestApp(options?: {
     replayService,
     routerService,
     meterService,
-    costService: createCostService(),
+    costService,
+    paymentService: createPaymentService({ costService }),
+    platformFeeBps: 50,
     ledgerService,
     traceService,
     receiptService: createReceiptService({ traceService, ledgerService }),

--- a/test/integration/flow.test.ts
+++ b/test/integration/flow.test.ts
@@ -26,7 +26,9 @@ describe("End-to-End Integration Flow", () => {
       expect(body.payment_requirements).toBeDefined();
       expect(body.payment_requirements.challenge_token).toBeDefined();
       expect(body.payment_requirements.quote_id).toBeDefined();
-      expect(body.payment_requirements.amount).toBe("0.001");
+      // Amount is now estimated from model pricing + token estimation (Issue #45)
+      expect(body.payment_requirements.amount).toBeDefined();
+      expect(parseFloat(body.payment_requirements.amount)).toBeGreaterThan(0);
       expect(body.payment_requirements.asset).toBe("USDC");
       expect(body.payment_requirements.chain).toBe("base");
     });
@@ -305,14 +307,25 @@ describe("End-to-End Integration Flow", () => {
     it("should reject expired challenge token", async () => {
       const { app, services } = buildMockedTestApp();
 
-      // Create an expired challenge
+      // Create an expired challenge with properly estimated amount
+      const challengeBody = {
+        model: "openai/gpt-4o",
+        messages: [{ role: "user", content: "Hello" }],
+      };
+      const challengePricing =
+        services.providerRegistry.getModelPricing("openai/gpt-4o");
+      const challengeTokens =
+        services.paymentService.estimateTokens(challengeBody);
+      const estimatedCost = services.paymentService.estimateTotalCost(
+        challengeTokens,
+        challengePricing,
+        services.platformFeeBps,
+      );
+
       const expiredChallenge =
         await services.challengeService.generateChallenge(
-          {
-            model: "openai/gpt-4o",
-            messages: [{ role: "user", content: "Hello" }],
-          },
-          "0.001",
+          challengeBody,
+          estimatedCost,
           "USDC",
           "base",
         );

--- a/test/simulation/environment.ts
+++ b/test/simulation/environment.ts
@@ -11,6 +11,7 @@ import { createProviderRegistry } from "../../src/provider/registry.js";
 import { createChallengeService } from "../../src/x402/challenge.service.js";
 import { createMeterService } from "../../src/billing/meter.service.js";
 import { createCostService } from "../../src/billing/cost.service.js";
+import { createPaymentService } from "../../src/billing/payment.service.js";
 import { createLedgerService } from "../../src/billing/ledger.service.js";
 import { createTraceService } from "../../src/audit/trace.service.js";
 import { createReceiptService } from "../../src/audit/receipt.service.js";
@@ -274,6 +275,7 @@ export function buildSimulationEnvironment(
   };
 } {
   const providerRegistry = createProviderRegistry();
+  const costService = createCostService();
   const ledgerService = createLedgerService();
   const traceService = createTraceService();
 
@@ -308,7 +310,9 @@ export function buildSimulationEnvironment(
     replayService: createSimulatedReplayService(),
     routerService: createSimulatedRouterService(config.providers),
     meterService: createMeterService({ recordUsage: async () => {} }),
-    costService: createCostService(),
+    costService,
+    paymentService: createPaymentService({ costService }),
+    platformFeeBps: 50,
     ledgerService,
     traceService,
     receiptService: createReceiptService({ traceService, ledgerService }),


### PR DESCRIPTION
## 关联 Issue
Closes #45

## 变更范围
- [x] **NEW** `src/billing/payment.service.ts` — 模块化支付金额层（协议无关，独立于 x402 challenge）
- [x] **NEW** `test/billing/payment.test.ts` — 13 个单元测试
- [x] `src/billing/index.ts` — 导出新服务
- [x] `src/config.ts` — 修正 `platformFeeBps` 默认值 500→50
- [x] `src/app.ts` — 注入 `paymentService` + `platformFeeBps` 到 ServiceContainer
- [x] `src/gateway/routes.ts` — 使用模型定价预估替代硬编码 `0.001`；增加执行后超额校验；消费配置的 `platformFeeBps`
- [x] `test/helpers.ts` — 测试容器注入 `paymentService`
- [x] `test/simulation/environment.ts` — 模拟容器注入 `paymentService`
- [x] `test/integration/flow.test.ts` — 更新 402 金额断言为动态校验

## 实现概要

### 核心变化
1. **挑战金额不再硬编码 0.001**：通过 `PaymentService.estimateTokens()` 估算 token + `estimateTotalCost()` 基于模型定价计算预估费用
2. **执行后超额校验**：实际费用 > 挑战授权金额时抛出 `InsufficientPaymentError` (402)
3. **platformFeeBps 配置化**：`routes.ts` 中的硬编码 `50` 改为从 `config.platformFeeBps` 注入；配置默认值从 500 修正为 50
4. **模块化支付金额层**：`PaymentService` 完全协议无关，仅处理金额预估和校验，为 #77 x402 v2 upto scheme 迁移做好准备

### PaymentService API
```
estimateTokens(request)        → 估算 prompt/completion token 数
estimateTotalCost(tokens, pricing, feeBps)  → 预估总费用
validatePayment(actualUsd, authorizedUsd)   → 实际≤授权？否则抛 InsufficientPaymentError
```

## 边界条件遵守
- [x] 未修改 /tmp/ 目录文件
- [x] 未修改已有接口签名（仅扩展 ServiceContainer 添加新字段）
- [x] 未重构现有代码
- [x] 改动 ≤ 500 行（9 files, +432/-14）
- [x] 未围绕 challenge 构造新的金额支付模块（PaymentService 协议无关）

## 测试证据
- [x] 单元测试覆盖率: **232 tests passed** (15 files)
- [x] 新增 `payment.test.ts`: 13 tests (estimateTokens, estimateTotalCost, validatePayment 全部覆盖)
- [x] TypeScript typecheck: ✅ 通过
- [x] 测试命令: `pnpm test` ✅ 全部通过

## 风险说明
- **预估偏差**：token 预估采用 `ceil(chars/4)` 启发式，可能导致预估过高（保守策略）；#77 upto scheme 将从根本上解决此问题
- **未知模型**：请求模型未注册时 `getModelPricing` 抛出异常，返回 500 — 与现状一致

## 回滚方案
```bash
git revert <commit-sha>
# 受影响的文件仅包含 billing 模块和 routes 集成，回滚无副作用
```