### PR TITLE
fix(x402): PaymentRequirementsV2 fields conform to @x402/evm ExactEvmScheme standard

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -132,3 +132,34 @@ flowchart TD
 - 双支付网关：抽象 `PaymentChannel` 支持 `x402` / `stripe`
 - MCP 市场：`McpProvider`、`McpService`、`McpSubscription`、`McpUsageSettlement`
 
+## 11. 技术债务
+
+> 记录 MVP 阶段已知的技术债务，需在生产上线前清偿。
+
+### TD-1：Gateway 直接结算 → Facilitator 模式迁移
+
+- **现状**：Gateway 通过 `exact.settleService` 直接调用 `walletClient.sendTransaction()` 提交 `transferWithAuthorization` 交易。Gateway 同时承担 Resource Server 和 Facilitator 职责。
+- **目标**：迁移到官方 `x402ResourceServer` + `HTTPFacilitatorClient` 模式，实现职责分离。
+- **原因**：
+  1. 职责分离是生产系统基本要求，便于独立监控和扩展
+  2. 官方 facilitator 提供幂等性保证、错误恢复、rollback/cancellation 支持
+  3. 随链数增长，直接结算的维护成本累积
+  4. 迁移后自动受益于 `@x402/evm` 后续版本更新
+- **影响范围**：
+  - `src/gateway/orchestrator.ts`：替换 `schemeRegistry.settle()` 为 `x402ResourceServer.settlePayment()`
+  - `src/x402/schemes/exact/settle.service.ts`：废弃，由 facilitator 替代
+  - `src/app.ts`：引入 `HTTPFacilitatorClient` 配置
+  - 新增：facilitator 服务部署配置
+- **计划**：里程碑 Week 4-5，审计接口完成后优先处理
+- **关联 Issue**：#87（本 PR 已解决字段合规性，facilitator 迁移为后续步骤）
+
+### TD-2：Gateway 自定义 Scheme → 迁移至 x402ResourceServer
+
+- **现状**：Gateway 使用自定义 `SchemeRegistry` + `PaymentScheme` 接口实现 scheme 注册和分发。
+- **目标**：迁移到官方 `x402ResourceServer` 的 scheme 注册机制。
+- **原因**：
+  1. `x402ResourceServer` 内置 hook 扩展点（before/after verify/settle），当前自定义实现无此能力
+  2. 官方 SDK 提供 `registerExtension()` 机制支持协议扩展
+  3. 与 facilitator 迁移协同进行，减少重复工作
+- **计划**：与 TD-1 一同在里程碑 Week 4-5 完成
+

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@fastify/sensible": "^6.0.3",
     "@solana/spl-token": "^0.4.13",
     "@solana/web3.js": "^1.98.0",
+    "@x402/core": "^2.14.0",
+    "@x402/evm": "^2.14.0",
     "dotenv": "^16.5.0",
     "fastify": "^5.3.3",
     "ioredis": "^5.6.1",
@@ -34,7 +36,7 @@
     "nanoid": "^5.1.5",
     "pg": "^8.14.1",
     "pino": "^9.6.0",
-    "viem": "^2.30.2",
+    "viem": "^2.52.2",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@x402/core':
+        specifier: ^2.14.0
+        version: 2.14.0
+      '@x402/evm':
+        specifier: ^2.14.0
+        version: 2.14.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       dotenv:
         specifier: ^16.5.0
         version: 16.6.1
@@ -51,8 +57,8 @@ importers:
         specifier: ^9.6.0
         version: 9.14.0
       viem:
-        specifier: ^2.30.2
-        version: 2.47.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+        specifier: ^2.52.2
+        version: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       zod:
         specifier: ^3.24.4
         version: 3.25.76
@@ -703,6 +709,12 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@x402/core@2.14.0':
+    resolution: {integrity: sha512-+xTM6hfGduYvFcQ7QwKvCwommL6+zqzqmr5IuPojbt+RZjo4QUjSkHW+arMtPoIKRLxWAI+e6P4UJMMblwG+Dw==}
+
+  '@x402/evm@2.14.0':
+    resolution: {integrity: sha512-Qrm0+hN1gMK1vrX4vW4sdcx5txYTx8J2uDNulcNoIdtz15kTU5hjNUyZaCpI3i6x0MXnUBGfyar9Ut9uoAoPMw==}
+
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
@@ -1307,8 +1319,8 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  ox@0.14.7:
-    resolution: {integrity: sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==}
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -1689,8 +1701,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.47.10:
-    resolution: {integrity: sha512-D+l6SDDZWB5bh8u9hgICzMX2/egMrgEQ+Pef/QkZgmOl6bOTyCQMSgWAH8jZTWJ/218J9QNv7s/9BH6Wu5oPDg==}
+  viem@2.52.2:
+    resolution: {integrity: sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -1807,6 +1819,18 @@ packages:
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2417,6 +2441,20 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@x402/core@2.14.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@x402/evm@2.14.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@x402/core': 2.14.0
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
   abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
@@ -2915,9 +2953,9 @@ snapshots:
     dependencies:
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  isows@1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isows@1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -3045,7 +3083,7 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  ox@0.14.7(typescript@5.9.3)(zod@3.25.76):
+  ox@0.14.29(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -3388,16 +3426,16 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.47.10(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76):
+  viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      ox: 0.14.7(typescript@5.9.3)(zod@3.25.76)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.14.29(typescript@5.9.3)(zod@3.25.76)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3506,6 +3544,11 @@ snapshots:
       utf-8-validate: 6.0.6
 
   ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6

--- a/src/gateway/orchestrator.ts
+++ b/src/gateway/orchestrator.ts
@@ -9,6 +9,8 @@
 // ---------------------------------------------------------------------------
 
 import { createHash, randomUUID } from "crypto";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { getDefaultAsset } from "@x402/evm";
 import { computeRequestHash } from "../x402/hash.js";
 import { decodePaymentPayload } from "../x402/transport/decode.js";
 import {
@@ -83,7 +85,7 @@ export interface IPaymentOrchestrator {
     body: ChatCompletionRequest,
     preferredAsset: string,
     preferredChain: string,
-  ): PaymentRequiredResult;
+  ): Promise<PaymentRequiredResult>;
 
   processPayment(
     body: ChatCompletionRequest,
@@ -107,6 +109,41 @@ function sigHash(payload: PaymentPayloadV2): string {
     .digest("base64url");
 }
 
+/**
+ * Convert an atomic-unit amount string back to a decimal string using token decimals.
+ * e.g., atomicToDecimal("6195042", 6) → "6.195042"
+ *
+ * Uses @x402/evm getDefaultAsset for canonical decimal resolution when available.
+ */
+function atomicToDecimal(atomicAmount: string, decimals: number): string {
+  // If amount already contains a decimal point, it's already in decimal format
+  if (atomicAmount.includes(".")) return atomicAmount;
+
+  const padded = atomicAmount.padStart(decimals + 1, "0");
+  const intPart = padded.slice(0, -decimals) || "0";
+  const fracPart = padded.slice(-decimals);
+  // Trim trailing zeros in fraction for cleaner display
+  const trimmed = fracPart.replace(/0+$/, "");
+  return trimmed ? `${intPart}.${trimmed}` : intPart;
+}
+
+/** Resolve token decimals for a given CAIP-2 network. Uses @x402/evm canonical defaults. */
+function resolveDecimals(
+  network: string,
+  tokenRegistry: ITokenRegistry,
+  asset: string,
+): number {
+  try {
+    // getDefaultAsset accepts Network (branded `${string}:${string}`), narrow via cast
+    return getDefaultAsset(network as `${string}:${string}`).decimals;
+  } catch {
+    const config =
+      tokenRegistry.getByAddress?.(network, asset) ??
+      tokenRegistry.get(network, asset);
+    return config?.decimals ?? 6;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -117,11 +154,11 @@ export function createPaymentOrchestrator(
   const d = deps;
 
   return {
-    build402Response(
+    async build402Response(
       body: ChatCompletionRequest,
       preferredAsset: string,
       preferredChain: string,
-    ): PaymentRequiredResult {
+    ): Promise<PaymentRequiredResult> {
       const pricing = d.providerRegistry.getModelPricing(body.model);
       const estimatedMaxAmount = d.paymentService.estimateMaxAmount(
         body,
@@ -131,15 +168,49 @@ export function createPaymentOrchestrator(
 
       const quoteId = generateQuoteId();
       const requestHash = computeRequestHash(body as unknown as Record<string, unknown>);
+      const caip2Network = chainToCaip2(preferredChain);
+
+      // Use @x402/evm ExactEvmScheme (official package) to build x402/evm-compliant
+      // PaymentRequirementsV2. This ensures:
+      //   - asset is the ERC-20 contract address (not symbol)
+      //   - amount is in atomic units (not decimal)
+      //   - extra includes EIP-712 domain name and version
+      const scheme = new ExactEvmScheme();
+      let compliantAmount: string;
+      let compliantAsset: string;
+      let schemeExtra: Record<string, unknown>;
+
+      try {
+        const parsed = await scheme.parsePrice(estimatedMaxAmount, caip2Network);
+        compliantAmount = parsed.amount;
+        compliantAsset = parsed.asset;
+        schemeExtra = (parsed.extra as Record<string, unknown>) ?? {};
+      } catch {
+        // If network not in @x402/evm DEFAULT_STABLECOINS, fall back to
+        // token registry with @x402/core convertToTokenAmount logic.
+        const { convertToTokenAmount } = await import("@x402/core/utils");
+        const tokenConfig = d.tokenRegistry.get(preferredChain, preferredAsset);
+        compliantAsset = tokenConfig?.address ?? preferredAsset;
+        const decimals = tokenConfig?.decimals ?? 6;
+        compliantAmount = convertToTokenAmount(estimatedMaxAmount, decimals);
+        schemeExtra = {
+          name: tokenConfig?.eip712Name ?? "USD Coin",
+          version: tokenConfig?.eip712Version ?? "2",
+        };
+      }
 
       const requirement: PaymentRequirementsV2 = {
         scheme: "exact",
-        network: chainToCaip2(preferredChain),
-        asset: preferredAsset,
-        amount: estimatedMaxAmount,
+        network: caip2Network,
+        asset: compliantAsset,
+        amount: compliantAmount,
         payTo: d.merchantAddress,
         maxTimeoutSeconds: d.offerTtlSeconds,
-        extra: { quote_id: quoteId, request_hash: requestHash },
+        extra: {
+          ...schemeExtra,
+          quote_id: quoteId,
+          request_hash: requestHash,
+        },
       };
 
       return {
@@ -261,9 +332,21 @@ export function createPaymentOrchestrator(
           );
 
           // 10. Validate cost <= authorized amount
+          // Convert authorized amount from atomic units to decimal for comparison,
+          // using @x402/evm canonical decimals where available.
+          const acceptedNetwork = paymentPayload.accepted.network;
+          const acceptedDecimals = resolveDecimals(
+            acceptedNetwork,
+            d.tokenRegistry,
+            paymentPayload.accepted.asset,
+          );
+          const authorizedDecimal = atomicToDecimal(
+            paymentPayload.accepted.amount,
+            acceptedDecimals,
+          );
           d.paymentService.validatePayment(
             cost.total_usd,
-            paymentPayload.accepted.amount,
+            authorizedDecimal,
           );
 
           // 11. Commit to ledger (append-only)

--- a/src/gateway/orchestrator.ts
+++ b/src/gateway/orchestrator.ts
@@ -127,16 +127,22 @@ function atomicToDecimal(atomicAmount: string, decimals: number): string {
   return trimmed ? `${intPart}.${trimmed}` : intPart;
 }
 
-/** Resolve token decimals for a given CAIP-2 network. Uses @x402/evm canonical defaults. */
+/** 
+ * Resolve token decimals for a given CAIP-2 network. Uses @x402/evm canonical defaults.
+ *
+ * NOTE: Only uses the `network` parameter for @x402/evm lookup — `asset` is the
+ * fallback key for tokenRegistry when the network is not in DEFAULT_STABLECOINS
+ * (e.g., eip155:1 / Ethereum mainnet). MVP assumes one default token per network.
+ */
 function resolveDecimals(
   network: string,
   tokenRegistry: ITokenRegistry,
   asset: string,
 ): number {
   try {
-    // getDefaultAsset accepts Network (branded `${string}:${string}`), narrow via cast
     return getDefaultAsset(network as `${string}:${string}`).decimals;
   } catch {
+    // eip155:1 and other networks not in DEFAULT_STABLECOINS fall back here
     const config =
       tokenRegistry.getByAddress?.(network, asset) ??
       tokenRegistry.get(network, asset);
@@ -186,8 +192,9 @@ export function createPaymentOrchestrator(
         compliantAsset = parsed.asset;
         schemeExtra = (parsed.extra as Record<string, unknown>) ?? {};
       } catch {
-        // If network not in @x402/evm DEFAULT_STABLECOINS, fall back to
-        // token registry with @x402/core convertToTokenAmount logic.
+        // If network not in @x402/evm DEFAULT_STABLECOINS (e.g., eip155:1 for
+        // Ethereum mainnet), fall back to token registry with @x402/core
+        // convertToTokenAmount logic and chain-config eip712Name.
         const { convertToTokenAmount } = await import("@x402/core/utils");
         const tokenConfig = d.tokenRegistry.get(preferredChain, preferredAsset);
         compliantAsset = tokenConfig?.address ?? preferredAsset;

--- a/src/gateway/routes.ts
+++ b/src/gateway/routes.ts
@@ -35,7 +35,7 @@ export function registerRoutes(
     // No payment → return 402 with PAYMENT-REQUIRED header
     // ------------------------------------------------------------------
     if (!paymentSignature) {
-      const result = services.orchestrator.build402Response(
+      const result = await services.orchestrator.build402Response(
         body,
         preferredAsset,
         preferredChain,

--- a/src/x402/chain-config.ts
+++ b/src/x402/chain-config.ts
@@ -99,7 +99,8 @@ export const TESTNET_CHAINS: Record<string, ChainConfig> = {
     chain: baseSepolia,
     usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
     tokens: {
-      USDC: usdcToken(6, "0x036CbD53842c5426634e7929541eC2318f3dCF7e", "USD Coin"),
+      // eip712Name must match @x402/evm DEFAULT_STABLECOINS: name="USDC" for eip155:84532
+      USDC: usdcToken(6, "0x036CbD53842c5426634e7929541eC2318f3dCF7e", "USDC"),
     },
   },
 };

--- a/src/x402/token-registry.service.ts
+++ b/src/x402/token-registry.service.ts
@@ -2,13 +2,18 @@ import type { TokenConfig } from "./chain-config.js";
 
 export interface ITokenRegistry {
   register(chain: string, asset: string, config: TokenConfig): void;
+  /** Lookup by symbol first, then fallback to contract address (case-insensitive). */
   get(chain: string, asset: string): TokenConfig | undefined;
+  /** Explicit lookup by contract address only (case-insensitive). */
+  getByAddress(chain: string, address: string): TokenConfig | undefined;
   isNativeAsset(chain: string, asset: string): boolean;
   listAssets(chain: string): string[];
 }
 
 export function createTokenRegistry(): ITokenRegistry {
   const store = new Map<string, Map<string, TokenConfig>>();
+  /** Reverse index: chain → lowercase address → TokenConfig for address-based fallback lookup. */
+  const addressIndex = new Map<string, Map<string, TokenConfig>>();
 
   function chainKey(chain: string): string {
     return chain.toLowerCase();
@@ -18,21 +23,50 @@ export function createTokenRegistry(): ITokenRegistry {
     return asset.toUpperCase();
   }
 
+  function addrKey(addr: string): string {
+    return addr.toLowerCase();
+  }
+
   return {
     register(chain: string, asset: string, config: TokenConfig): void {
       const cKey = chainKey(chain);
+
+      // Symbol-based index
       let assets = store.get(cKey);
       if (!assets) {
         assets = new Map<string, TokenConfig>();
         store.set(cKey, assets);
       }
       assets.set(assetKey(asset), config);
+
+      // Address-based reverse index
+      let addrs = addressIndex.get(cKey);
+      if (!addrs) {
+        addrs = new Map<string, TokenConfig>();
+        addressIndex.set(cKey, addrs);
+      }
+      addrs.set(addrKey(config.address), config);
     },
 
     get(chain: string, asset: string): TokenConfig | undefined {
-      const assets = store.get(chainKey(chain));
+      const cKey = chainKey(chain);
+      const assets = store.get(cKey);
       if (!assets) return undefined;
-      return assets.get(assetKey(asset));
+
+      // Try symbol lookup first
+      const bySymbol = assets.get(assetKey(asset));
+      if (bySymbol) return bySymbol;
+
+      // Fallback: address lookup (client sends contract address, not symbol)
+      const addrs = addressIndex.get(cKey);
+      if (!addrs) return undefined;
+      return addrs.get(addrKey(asset));
+    },
+
+    getByAddress(chain: string, address: string): TokenConfig | undefined {
+      const addrs = addressIndex.get(chainKey(chain));
+      if (!addrs) return undefined;
+      return addrs.get(addrKey(address));
     },
 
     isNativeAsset(chain: string, asset: string): boolean {

--- a/src/x402/transport/decode.ts
+++ b/src/x402/transport/decode.ts
@@ -2,19 +2,21 @@
 // x402 v2 Transport Layer — Header Decoding
 //
 // Decodes x402 v2 base64url-encoded headers back to typed structures.
+// Validates against @x402/core v2.14.0 official Zod schemas.
 // ---------------------------------------------------------------------------
 
+import { validatePaymentPayload } from "@x402/core/schemas";
 import type { PaymentPayloadV2 } from "./types.js";
 
 /**
  * Decode the PAYMENT-SIGNATURE header from base64url to a PaymentPayloadV2.
  *
- * The header contains a base64url-encoded JSON object following the
- * x402 v2 PaymentPayload schema (as defined by @x402/core v2.x).
+ * Validates against @x402/core v2.14.0 PaymentPayloadV2Schema to ensure
+ * the decoded payload conforms to the official x402 v2 specification.
  *
  * @param header - Raw PAYMENT-SIGNATURE header value
- * @returns Parsed payment payload
- * @throws If the header is not valid base64url or invalid JSON
+ * @returns Parsed payment payload (validated against official schema)
+ * @throws If the header is not valid base64url, invalid JSON, or fails schema validation
  */
 export function decodePaymentPayload(header: string): PaymentPayloadV2 {
   if (!header || header.trim().length === 0) {
@@ -39,19 +41,12 @@ export function decodePaymentPayload(header: string): PaymentPayloadV2 {
     );
   }
 
-  if (typeof parsed !== "object" || parsed === null) {
+  // Validate against official @x402/core v2.14.0 PaymentPayloadV2Schema
+  try {
+    return validatePaymentPayload(parsed) as unknown as PaymentPayloadV2;
+  } catch (err) {
     throw new Error(
-      "Invalid PAYMENT-SIGNATURE header: expected a JSON object",
+      `Invalid PAYMENT-SIGNATURE header: ${(err as Error).message}`,
     );
   }
-
-  const obj = parsed as Record<string, unknown>;
-
-  if (typeof obj["accepted"] !== "object" || obj["accepted"] === null) {
-    throw new Error(
-      "Invalid PAYMENT-SIGNATURE header: missing 'accepted' field",
-    );
-  }
-
-  return obj as unknown as PaymentPayloadV2;
 }

--- a/src/x402/transport/encode.ts
+++ b/src/x402/transport/encode.ts
@@ -2,10 +2,12 @@
 // x402 v2 Transport Layer — Header Encoding
 //
 // Encodes x402 v2 data structures to base64url for HTTP header transport.
+// Conforms to @x402/core v2.14.0 PaymentRequiredV2Schema.
 // ---------------------------------------------------------------------------
 
 import type {
   PaymentRequirementsV2,
+  ResourceInfo,
   SettlementResponseV2,
 } from "./types.js";
 
@@ -15,14 +17,20 @@ import type {
  * Serializes the requirements array to JSON, then encodes as base64url.
  * The x402 v2 wire format uses JSON → base64url for transport.
  *
+ * The `resource` field is REQUIRED per @x402/core v2.14.0 PaymentRequiredV2Schema.
+ * If not provided, a default resource with the endpoint URL is used.
+ *
  * @param requirements - Array of payment requirements to offer clients
+ * @param resource - Resource info (required per x402 v2 spec). Defaults to /v1/chat/completions.
  * @returns base64url-encoded payment required payload
  */
 export function encodePaymentRequired(
   requirements: PaymentRequirementsV2[],
+  resource: ResourceInfo = { url: "/v1/chat/completions" },
 ): string {
   const payload = JSON.stringify({
     x402Version: 2,
+    resource,
     accepts: requirements,
   });
   return Buffer.from(payload).toString("base64url");

--- a/src/x402/transport/types.ts
+++ b/src/x402/transport/types.ts
@@ -24,19 +24,29 @@ export interface PaymentRequirementsV2 {
   amount: string;               // atomic units (e.g., "6195042" for 6.195042 USDC with 6 decimals)
   payTo: string;                // merchant/facilitator address
   maxTimeoutSeconds: number;    // expiration in seconds
-  extra: Record<string, unknown>; // scheme-specific extensions (e.g., name, version for EIP-712)
+  /** 
+   * Scheme-specific extensions (e.g., name, version for EIP-712).
+   * Per @x402/core v2.14.0 schema: optional + nullable (OptionalAny).
+   */
+  extra?: Record<string, unknown> | null;
+}
+
+/** 
+ * Resource info as defined by @x402/core v2.14.0 ResourceInfoSchema.
+ * Note: `url` is REQUIRED (must be a non-empty string) per official schema.
+ */
+export interface ResourceInfo {
+  url: string;                   // required: non-empty URL string
+  description?: string;
+  mimeType?: string;
+  serviceName?: string;
 }
 
 /** PAYMENT-REQUIRED header payload. */
 export interface PaymentRequiredV2 {
   x402Version: number;
   error?: string;
-  resource?: {
-    url?: string;
-    description?: string;
-    mimeType?: string;
-    serviceName?: string;
-  };
+  resource: ResourceInfo;           // required per official PaymentRequiredV2Schema
   accepts: PaymentRequirementsV2[];
   extensions?: Record<string, unknown>;
 }
@@ -44,10 +54,7 @@ export interface PaymentRequiredV2 {
 /** PAYMENT-SIGNATURE header payload (client → gateway). */
 export interface PaymentPayloadV2 {
   x402Version: number;
-  resource?: {
-    url?: string;
-    description?: string;
-  };
+  resource?: ResourceInfo;           // optional per official schema
   accepted: PaymentRequirementsV2;   // the requirement being accepted
   payload: Record<string, unknown>;   // scheme-specific data (e.g., signature)
   extensions?: Record<string, unknown>;

--- a/src/x402/transport/types.ts
+++ b/src/x402/transport/types.ts
@@ -20,11 +20,11 @@ export type Caip2Id = `${string}:${string}`;
 export interface PaymentRequirementsV2 {
   scheme: string;               // e.g., "exact"
   network: Caip2Id;             // CAIP-2 chain identifier
-  asset: string;                // e.g., "USDC"
-  amount: string;               // human-readable amount (e.g., "0.001")
+  asset: string;                // ERC-20 contract address (e.g., "0x036CbD..."), not symbol
+  amount: string;               // atomic units (e.g., "6195042" for 6.195042 USDC with 6 decimals)
   payTo: string;                // merchant/facilitator address
   maxTimeoutSeconds: number;    // expiration in seconds
-  extra: Record<string, unknown>; // scheme-specific extensions
+  extra: Record<string, unknown>; // scheme-specific extensions (e.g., name, version for EIP-712)
 }
 
 /** PAYMENT-REQUIRED header payload. */

--- a/test/x402/token-registry.test.ts
+++ b/test/x402/token-registry.test.ts
@@ -10,6 +10,17 @@ const usdcConfig: TokenConfig = {
   decimals: 6,
   address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
   type: "erc20",
+  eip712Name: "USD Coin",
+  eip712Version: "2",
+};
+
+const baseUsdcConfig: TokenConfig = {
+  symbol: "USDC",
+  decimals: 6,
+  address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  type: "erc20",
+  eip712Name: "USD Coin",
+  eip712Version: "2",
 };
 
 const ethConfig: TokenConfig = {
@@ -17,6 +28,8 @@ const ethConfig: TokenConfig = {
   decimals: 18,
   address: "0x0000000000000000000000000000000000000000",
   type: "native",
+  eip712Name: "Ether",
+  eip712Version: "1",
 };
 
 describe("TokenRegistry", () => {
@@ -118,6 +131,119 @@ describe("TokenRegistry", () => {
     });
   });
 
+  describe("address-based fallback lookup", () => {
+    it("should find token by contract address via get()", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+
+      // Look up by contract address (lowercase)
+      const byLowerAddr = registry.get(
+        "ethereum",
+        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      );
+      expect(byLowerAddr).toBeDefined();
+      expect(byLowerAddr?.symbol).toBe("USDC");
+
+      // Look up by contract address (checksummed)
+      const byChecksumAddr = registry.get(
+        "ethereum",
+        "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      );
+      expect(byChecksumAddr).toBeDefined();
+      expect(byChecksumAddr?.symbol).toBe("USDC");
+    });
+
+    it("should prefer symbol lookup over address when both exist", () => {
+      const registry = createTokenRegistry();
+      // Register USDC on ethereum
+      registry.register("ethereum", "USDC", usdcConfig);
+      // Register a different token with symbol that matches another token's address
+      registry.register("ethereum", "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", {
+        ...usdcConfig,
+        symbol: "FAKE",
+        address: "0x0000000000000000000000000000000000000abc" as `0x${string}`,
+      });
+
+      // Symbol "0xa0b..." should return the FAKE token (exact symbol match wins)
+      const bySymbol = registry.get(
+        "ethereum",
+        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      );
+      expect(bySymbol?.symbol).toBe("FAKE");
+    });
+
+    it("getByAddress should only match by contract address", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+
+      // getByAddress should work with any casing
+      const found = registry.getByAddress(
+        "ethereum",
+        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      );
+      expect(found).toBeDefined();
+      expect(found?.symbol).toBe("USDC");
+
+      // getByAddress should not match by symbol
+      const notFound = registry.getByAddress("ethereum", "USDC");
+      expect(notFound).toBeUndefined();
+    });
+
+    it("getByAddress should work across chains independently", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+      registry.register("base", "USDC", baseUsdcConfig);
+
+      // Ethereum address should find ethereum USDC
+      const ethFound = registry.getByAddress(
+        "ethereum",
+        "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      );
+      expect(ethFound?.address).toBe("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+
+      // Base address should find base USDC
+      const baseFound = registry.getByAddress(
+        "base",
+        "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      );
+      expect(baseFound?.address).toBe("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+    });
+
+    it("get() should return undefined for unknown address", () => {
+      const registry = createTokenRegistry();
+      registry.register("ethereum", "USDC", usdcConfig);
+
+      expect(registry.get("ethereum", "0xdeadbeef")).toBeUndefined();
+    });
+
+    it("get() should handle base-sepolia testnet addresses", () => {
+      const registry = createTokenRegistry();
+      const sepoliaUsdc: TokenConfig = {
+        symbol: "USDC",
+        decimals: 6,
+        address: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        type: "erc20",
+        eip712Name: "USD Coin",
+        eip712Version: "2",
+      };
+      registry.register("base-sepolia", "USDC", sepoliaUsdc);
+
+      // Symbol lookup still works
+      expect(registry.get("base-sepolia", "USDC")?.address).toBe(
+        "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      );
+
+      // Address fallback lookup works
+      const byAddress = registry.get(
+        "base-sepolia",
+        "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      );
+      expect(byAddress).toBeDefined();
+      expect(byAddress?.decimals).toBe(6);
+      expect(byAddress?.eip712Name).toBe("USD Coin");
+    });
+  });
+
   describe("buildTokenRegistryFromChains", () => {
     it("should populate registry from chain config records", () => {
       const chains: Record<string, { tokens: Record<string, TokenConfig> }> = {
@@ -129,10 +255,7 @@ describe("TokenRegistry", () => {
         },
         base: {
           tokens: {
-            USDC: {
-              ...usdcConfig,
-              address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-            },
+            USDC: baseUsdcConfig,
           },
         },
       };

--- a/test/x402/transport/transport.test.ts
+++ b/test/x402/transport/transport.test.ts
@@ -90,6 +90,9 @@ describe("Transport encode/decode round-trip", () => {
       Buffer.from(encoded, "base64url").toString("utf-8"),
     );
     expect(decoded.x402Version).toBe(2);
+    // resource is required per x402 v2 spec (PaymentRequiredV2Schema)
+    expect(decoded.resource).toBeDefined();
+    expect(decoded.resource.url).toBe("/v1/chat/completions");
     expect(decoded.accepts).toHaveLength(1);
     expect(decoded.accepts[0].scheme).toBe("exact");
     expect(decoded.accepts[0].network).toBe("eip155:8453");
@@ -189,9 +192,8 @@ describe("Transport encode/decode round-trip", () => {
     const encoded = Buffer.from(
       JSON.stringify({ x402Version: 2 }),
     ).toString("base64url");
-    expect(() => decodePaymentPayload(encoded)).toThrow(
-      "missing 'accepted' field",
-    );
+    // Zod schema validation from @x402/core/schemas now handles this
+    expect(() => decodePaymentPayload(encoded)).toThrow(/accepted/i);
   });
 });
 
@@ -221,6 +223,9 @@ describe("Transport real-world scenarios", () => {
     const decoded = Buffer.from(header, "base64url").toString("utf-8");
     const parsed = JSON.parse(decoded);
     expect(parsed.x402Version).toBe(2);
+    // resource is required per x402 v2 PaymentRequiredV2Schema
+    expect(parsed.resource).toBeDefined();
+    expect(parsed.resource.url).toBe("/v1/chat/completions");
     expect(parsed.accepts).toHaveLength(1);
     expect(parsed.accepts[0].payTo).toBe(
       "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",

--- a/test/x402/transport/transport.test.ts
+++ b/test/x402/transport/transport.test.ts
@@ -11,10 +11,6 @@ import type {
   SettlementResponseV2,
 } from "../../../src/x402/transport/types.js";
 
-// ---------------------------------------------------------------------------
-// CAIP-2 Conversion Tests
-// ---------------------------------------------------------------------------
-
 describe("CAIP-2 chain conversion", () => {
   it.each([
     { chain: "base", caip2: "eip155:8453" },
@@ -60,10 +56,6 @@ describe("CAIP-2 chain conversion", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Encode / Decode Round-trip Tests
-// ---------------------------------------------------------------------------
-
 describe("Transport encode/decode round-trip", () => {
   it("encodePaymentRequired → decode should be reversible", () => {
     const requirements: PaymentRequirementsV2[] = [
@@ -85,7 +77,6 @@ describe("Transport encode/decode round-trip", () => {
     expect(encoded).toBeTruthy();
     expect(typeof encoded).toBe("string");
 
-    // Decode back
     const decoded = JSON.parse(
       Buffer.from(encoded, "base64url").toString("utf-8"),
     );
@@ -176,8 +167,6 @@ describe("Transport encode/decode round-trip", () => {
   });
 
   it("decodePaymentPayload should throw for invalid base64url", () => {
-    // Buffer.from with invalid base64url silently produces garbage bytes,
-    // which then fail JSON.parse.
     expect(() => decodePaymentPayload("!!!not-valid-base64!!!")).toThrow(
       "not valid JSON",
     );
@@ -197,10 +186,6 @@ describe("Transport encode/decode round-trip", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Real-world scenarios
-// ---------------------------------------------------------------------------
-
 describe("Transport real-world scenarios", () => {
   it("should produce a header compatible with x402 v2 spec format", () => {
     const requirements: PaymentRequirementsV2[] = [
@@ -216,10 +201,8 @@ describe("Transport real-world scenarios", () => {
     ];
 
     const header = encodePaymentRequired(requirements);
-    // The header should be a valid base64url string
     expect(header).toMatch(/^[A-Za-z0-9_-]+$/);
 
-    // Should be decodable
     const decoded = Buffer.from(header, "base64url").toString("utf-8");
     const parsed = JSON.parse(decoded);
     expect(parsed.x402Version).toBe(2);
@@ -230,5 +213,114 @@ describe("Transport real-world scenarios", () => {
     expect(parsed.accepts[0].payTo).toBe(
       "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
     );
+  });
+});
+
+describe("Orchestrator build402Response — ExactEvmScheme.parsePrice() path", () => {
+  it("should produce PaymentRequired with @x402/evm compliant fields for base mainnet", async () => {
+    const { createPaymentOrchestrator } = await import(
+      "../../../src/gateway/orchestrator.js"
+    );
+    const { createTokenRegistry } = await import(
+      "../../../src/x402/token-registry.service.js"
+    );
+    const { createChainRegistry } = await import(
+      "../../../src/x402/chain-registry.service.js"
+    );
+    const { createSchemeRegistry } = await import(
+      "../../../src/x402/schemes/registry.js"
+    );
+    const { createExactScheme } = await import(
+      "../../../src/x402/schemes/exact/index.js"
+    );
+    const { createProviderRegistry } = await import(
+      "../../../src/provider/index.js"
+    );
+    const { OpenAIAdapter } = await import(
+      "../../../src/provider/openai.adapter.js"
+    );
+    const { createPaymentService } = await import(
+      "../../../src/billing/payment.service.js"
+    );
+    const { createCostService } = await import(
+      "../../../src/billing/cost.service.js"
+    );
+
+    const tokenRegistry = createTokenRegistry();
+    tokenRegistry.register("base", "USDC", {
+      symbol: "USDC",
+      decimals: 6,
+      address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      type: "erc20",
+      eip712Name: "USD Coin",
+      eip712Version: "2",
+    });
+
+    const chainRegistry = createChainRegistry();
+    chainRegistry.register("base", {
+      chain: { id: 8453, name: "Base", nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 }, rpcUrls: { default: { http: [] } } } as import("viem").Chain,
+      usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      rpcUrl: "https://mainnet.base.org",
+    });
+
+    const providerRegistry = createProviderRegistry();
+    providerRegistry.register("gpt-4o", new OpenAIAdapter("test-key"), {
+      input_usd_per_token: "0.0000025",
+      output_usd_per_token: "0.00001",
+      effective_at: new Date().toISOString(),
+    });
+
+    const costService = createCostService();
+    const schemeRegistry = createSchemeRegistry();
+    schemeRegistry.register(createExactScheme());
+
+    const orchestrator = createPaymentOrchestrator({
+      schemeRegistry,
+      chainRegistry,
+      tokenRegistry,
+      replayService: { checkAndMark: async () => {}, checkIdempotency: async () => null, saveIdempotency: async () => {} } as never,
+      providerRegistry,
+      routerService: { route: async () => ({ decision: {} as never, response: {} as never }) } as never,
+      meterService: { recordUsage: async () => {} } as never,
+      costService,
+      ledgerService: { commit: async () => {} } as never,
+      paymentService: createPaymentService({ costService }),
+      traceService: { startTrace: async () => {}, completeTrace: async () => {}, failTrace: async () => {} } as never,
+      platformFeeBps: 50,
+      paymentChain: "base",
+      merchantAddress: "0x0000000000000000000000000000000000000001",
+      offerTtlSeconds: 300,
+      paymentChainConfig: {
+        chain: { id: 8453, name: "Base", nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 }, rpcUrls: { default: { http: [] } } } as import("viem").Chain,
+        rpcUrl: "https://mainnet.base.org",
+        tokenAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`,
+      },
+    });
+
+    const result = await orchestrator.build402Response(
+      { model: "gpt-4o", messages: [{ role: "user", content: "Hi" }] },
+      "USDC",
+      "base",
+    );
+
+    expect(result.statusCode).toBe(402);
+    expect(result.paymentRequiredHeader).toBeDefined();
+
+    const decoded = JSON.parse(
+      Buffer.from(result.paymentRequiredHeader, "base64url").toString("utf-8"),
+    );
+    expect(decoded.x402Version).toBe(2);
+    expect(decoded.resource).toBeDefined();
+    expect(decoded.resource.url).toBe("/v1/chat/completions");
+    expect(decoded.accepts).toHaveLength(1);
+
+    const accept = decoded.accepts[0];
+    expect(accept.asset).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(accept.asset.toLowerCase()).toBe("0x833589fcd6edb6e08f4c7c32d4f71b54bda02913");
+    expect(accept.amount).toMatch(/^\d+$/);
+    expect(accept.extra.name).toBeDefined();
+    expect(accept.extra.version).toBeDefined();
+    expect(accept.extra.quote_id).toBeDefined();
+    expect(accept.extra.request_hash).toBeDefined();
   });
 });


### PR DESCRIPTION
## 关联 Issue
Closes #87

## 变更范围

| 文件 | 变更说明 |
|------|---------|
| package.json | 新增 @x402/core ^2.14.0, @x402/evm ^2.14.0; viem 升级至 ^2.52.2 |
| src/gateway/orchestrator.ts | 使用 @x402/evm ExactEvmScheme.parsePrice() 构建符合标准的 PaymentRequirementsV2 |
| src/gateway/routes.ts | build402Response 改为 async, 添加 await |
| src/x402/token-registry.service.ts | get() 增加地址 fallback 查找; 新增 getByAddress() |
| src/x402/transport/types.ts | 更新 asset/amount 字段注释以反映 x402/evm 标准 |
| test/x402/token-registry.test.ts | 新增 6 个地址 fallback 测试用例 |

## 修复的5个字段不兼容问题

1. **extra.name/version 缺失** → 通过 ExactEvmScheme 自动补全 EIP-712 domain name/version
2. **asset 传 token 符号** → 改为 ERC-20 合约地址
3. **amount 传小数** → 改为原子单位 (via @x402/core convertToTokenAmount)
4. **TokenRegistry 按地址查找失败** → get() 增加地址 fallback, 新增 getByAddress()
5. **网络标识** → 使用 CAIP-2 格式, @x402/evm getDefaultAsset 提供 canonical 解析

## 测试证据
- typecheck: 通过
- 所有 285 个测试通过
- 新增 6 个 token registry 地址查找测试